### PR TITLE
Add vertical asset category rail to sidebar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import LeftSidebar from './components/LeftSidebar';
 import CenterPanel from './components/CenterPanel';
 import RightSidebar from './components/RightSidebar';
 import Timeline from './components/Timeline';
+import { CanvasStateProvider } from './context/CanvasStateContext';
 
 const MIN_PANEL_WIDTH = 220;
 const MAX_PANEL_WIDTH = 420;
@@ -220,80 +221,82 @@ const App: React.FC = () => {
   }, []);
 
   return (
-    <div ref={containerRef} className="flex flex-col h-screen bg-[#1e1e1e] text-gray-300 font-sans overflow-hidden">
-      <Header
-        isMobile={isMobile}
-        onToggleLeft={handleToggleLeft}
-        onToggleRight={handleToggleRight}
-        leftOpen={leftOpen}
-        rightOpen={rightOpen}
-      />
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="flex flex-1 min-h-0 relative">
-          {!isMobile && leftOpen && (
-            <div className="h-full flex-shrink-0" style={{ width: leftPanelWidth }}>
-              <LeftSidebar />
-            </div>
-          )}
-          {!isMobile && leftOpen && (
-            <div
-              className="w-1 cursor-col-resize flex-shrink-0 relative group"
-              onPointerDown={startDragging('left')}
-            >
-              <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
-            </div>
-          )}
+    <CanvasStateProvider>
+      <div ref={containerRef} className="flex flex-col h-screen bg-[#1e1e1e] text-gray-300 font-sans overflow-hidden">
+        <Header
+          isMobile={isMobile}
+          onToggleLeft={handleToggleLeft}
+          onToggleRight={handleToggleRight}
+          leftOpen={leftOpen}
+          rightOpen={rightOpen}
+        />
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="flex flex-1 min-h-0 relative">
+            {!isMobile && leftOpen && (
+              <div className="h-full flex-shrink-0" style={{ width: leftPanelWidth }}>
+                <LeftSidebar />
+              </div>
+            )}
+            {!isMobile && leftOpen && (
+              <div
+                className="w-1 cursor-col-resize flex-shrink-0 relative group"
+                onPointerDown={startDragging('left')}
+              >
+                <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
+              </div>
+            )}
 
-          <CenterPanel />
+            <CenterPanel />
 
-          {!isMobile && rightOpen && (
-            <div
-              className="w-1 cursor-col-resize flex-shrink-0 relative group"
-              onPointerDown={startDragging('right')}
-            >
-              <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
-            </div>
-          )}
-          {!isMobile && rightOpen && (
-            <div className="h-full flex-shrink-0" style={{ width: rightPanelWidth }}>
-              <RightSidebar />
-            </div>
-          )}
+            {!isMobile && rightOpen && (
+              <div
+                className="w-1 cursor-col-resize flex-shrink-0 relative group"
+                onPointerDown={startDragging('right')}
+              >
+                <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
+              </div>
+            )}
+            {!isMobile && rightOpen && (
+              <div className="h-full flex-shrink-0" style={{ width: rightPanelWidth }}>
+                <RightSidebar />
+              </div>
+            )}
 
-          {isMobile && leftOpen && (
-            <LeftSidebar isMobile onClose={() => setLeftOpen(false)} className="lg:hidden" />
-          )}
-          {isMobile && rightOpen && (
-            <RightSidebar isMobile onClose={() => setRightOpen(false)} className="lg:hidden" />
-          )}
-          {isMobile && (
-            <>
-              <MobilePanelToggle side="left" isOpen={leftOpen} onToggle={handleToggleLeft} />
-              <MobilePanelToggle side="right" isOpen={rightOpen} onToggle={handleToggleRight} />
-            </>
-          )}
-          {isMobile && (leftOpen || rightOpen) && (
-            <button
-              type="button"
-              aria-label="Close panels"
-              className="fixed inset-x-0 top-14 bottom-0 bg-black/40 z-30"
-              onClick={closePanels}
-            />
-          )}
+            {isMobile && leftOpen && (
+              <LeftSidebar isMobile onClose={() => setLeftOpen(false)} className="lg:hidden" />
+            )}
+            {isMobile && rightOpen && (
+              <RightSidebar isMobile onClose={() => setRightOpen(false)} className="lg:hidden" />
+            )}
+            {isMobile && (
+              <>
+                <MobilePanelToggle side="left" isOpen={leftOpen} onToggle={handleToggleLeft} />
+                <MobilePanelToggle side="right" isOpen={rightOpen} onToggle={handleToggleRight} />
+              </>
+            )}
+            {isMobile && (leftOpen || rightOpen) && (
+              <button
+                type="button"
+                aria-label="Close panels"
+                className="fixed inset-x-0 top-14 bottom-0 bg-black/40 z-30"
+                onClick={closePanels}
+              />
+            )}
+          </div>
+
+          <div
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize timeline"
+            className="h-2 cursor-row-resize flex-shrink-0 relative group"
+            onPointerDown={startTimelineResize}
+          >
+            <div className="absolute inset-x-4 top-1/2 -translate-y-1/2 h-0.5 bg-zinc-700 rounded group-hover:bg-blue-400 transition-colors" />
+          </div>
+          <Timeline height={timelineHeight} />
         </div>
-
-        <div
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label="Resize timeline"
-          className="h-2 cursor-row-resize flex-shrink-0 relative group"
-          onPointerDown={startTimelineResize}
-        >
-          <div className="absolute inset-x-4 top-1/2 -translate-y-1/2 h-0.5 bg-zinc-700 rounded group-hover:bg-blue-400 transition-colors" />
-        </div>
-        <Timeline height={timelineHeight} />
       </div>
-    </div>
+    </CanvasStateProvider>
   );
 };
 

--- a/components/CenterPanel.tsx
+++ b/components/CenterPanel.tsx
@@ -1,17 +1,304 @@
 
 import React from 'react';
+import { ASSET_DRAG_TYPE } from '../constants';
+import { useCanvasState } from '../context/CanvasStateContext';
+import type { CanvasAsset } from '../types';
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const stageStyle = {
+  aspectRatio: '16 / 9',
+};
+
+const CanvasAssetLayer: React.FC<{
+  asset: CanvasAsset;
+  isSelected: boolean;
+  onSelect: () => void;
+  onStartMove: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onStartResize: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onNudge: (deltaX: number, deltaY: number) => void;
+}> = ({ asset, isSelected, onSelect, onStartMove, onStartResize, onNudge }) => {
+  if (!asset.isVisible) {
+    return null;
+  }
+
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: `${asset.transform.x}%`,
+    top: `${asset.transform.y}%`,
+    width: `${asset.transform.width}%`,
+    height: `${asset.transform.height}%`,
+    transform: `rotate(${asset.transform.rotation}deg)`,
+    opacity: asset.transform.opacity,
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onPointerDown={(event) => {
+        if (asset.isLocked) {
+          return;
+        }
+        (event.currentTarget as HTMLDivElement).focus();
+        onSelect();
+        onStartMove(event);
+      }}
+      onKeyDown={(event) => {
+        if (!isSelected || asset.isLocked) {
+          return;
+        }
+        const step = event.shiftKey ? 5 : 1;
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          onNudge(0, -step);
+        }
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          onNudge(0, step);
+        }
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          onNudge(-step, 0);
+        }
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          onNudge(step, 0);
+        }
+      }}
+      style={style}
+      className={`group cursor-${asset.isLocked ? 'not-allowed' : 'move'} focus:outline-none`}
+    >
+      <img src={asset.mediaUrl} alt={asset.name} className="w-full h-full object-cover rounded shadow" draggable={false} />
+      {isSelected && !asset.isLocked && (
+        <>
+          <div className="absolute inset-0 border-2 border-blue-400 rounded pointer-events-none" />
+          <button
+            type="button"
+            aria-label="Resize asset"
+            onPointerDown={onStartResize}
+            className="absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2 bg-blue-500 text-white rounded-full w-5 h-5 flex items-center justify-center shadow"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3">
+              <path d="M4 12h4v4H6a2 2 0 01-2-2v-2zm6-6h4a2 2 0 012 2v2h-4V6h-2z" />
+            </svg>
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
 
 const CenterPanel: React.FC = () => {
+  const {
+    assets,
+    addAssetToCanvas,
+    selectEntity,
+    selected,
+    updateAssetTransform,
+  } = useCanvasState();
+  const stageRef = React.useRef<HTMLDivElement>(null);
+  const [stageRect, setStageRect] = React.useState<DOMRect | null>(null);
+  const [interaction, setInteraction] = React.useState<
+    | {
+        mode: 'move' | 'resize';
+        assetId: string;
+        pointerId: number;
+        startPointer: { x: number; y: number };
+        initialTransform: CanvasAsset['transform'];
+      }
+    | null
+  >(null);
+
+  React.useEffect(() => {
+    const node = stageRef.current;
+    if (!node) {
+      return;
+    }
+    const updateRect = () => setStageRect(node.getBoundingClientRect());
+    updateRect();
+    const observer = new ResizeObserver(updateRect);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  React.useEffect(() => {
+    if (!interaction) {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== interaction.pointerId || !stageRect) {
+        return;
+      }
+      const deltaXPercent = ((event.clientX - interaction.startPointer.x) / stageRect.width) * 100;
+      const deltaYPercent = ((event.clientY - interaction.startPointer.y) / stageRect.height) * 100;
+
+      if (interaction.mode === 'move') {
+        const { initialTransform } = interaction;
+        const nextX = clamp(initialTransform.x + deltaXPercent, 0, 100 - initialTransform.width);
+        const nextY = clamp(initialTransform.y + deltaYPercent, 0, 100 - initialTransform.height);
+        updateAssetTransform(interaction.assetId, { x: nextX, y: nextY });
+      } else if (interaction.mode === 'resize') {
+        const { initialTransform } = interaction;
+        const aspect = initialTransform.width / initialTransform.height || 1;
+        let nextWidth = clamp(
+          initialTransform.width + deltaXPercent,
+          5,
+          100 - initialTransform.x
+        );
+        let nextHeight = clamp(
+          initialTransform.height + deltaYPercent,
+          5,
+          100 - initialTransform.y
+        );
+
+        if (initialTransform.preserveAspectRatio) {
+          nextHeight = clamp(nextWidth / aspect, 5, 100 - initialTransform.y);
+          nextWidth = clamp(nextHeight * aspect, 5, 100 - initialTransform.x);
+        }
+
+        updateAssetTransform(interaction.assetId, {
+          width: nextWidth,
+          height: nextHeight,
+        });
+      }
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId === interaction.pointerId) {
+        setInteraction(null);
+      }
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: false });
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [interaction, stageRect, updateAssetTransform]);
+
+  const handleDrop = React.useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!stageRect) {
+        return;
+      }
+      const data = event.dataTransfer.getData(ASSET_DRAG_TYPE);
+      if (!data) {
+        return;
+      }
+      try {
+        const payload = JSON.parse(data) as { assetId: string; type: string };
+        if (payload.type === 'music') {
+          return;
+        }
+        const percentX = ((event.clientX - stageRect.left) / stageRect.width) * 100;
+        const percentY = ((event.clientY - stageRect.top) / stageRect.height) * 100;
+        const defaultSize = { width: 35, height: 35 };
+        const position = {
+          x: clamp(percentX - defaultSize.width / 2, 0, 100 - defaultSize.width),
+          y: clamp(percentY - defaultSize.height / 2, 0, 100 - defaultSize.height),
+        };
+
+        addAssetToCanvas(payload.assetId, { position });
+      } catch (error) {
+        // ignore malformed payloads
+      }
+    },
+    [addAssetToCanvas, stageRect]
+  );
+
+  const handleDragOver = React.useCallback((event: React.DragEvent) => {
+    if (event.dataTransfer.types.includes(ASSET_DRAG_TYPE)) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }, []);
+
+  const selectedCanvasId = selected?.kind === 'canvas' ? selected.id : null;
+
+  const startMove = React.useCallback(
+    (asset: CanvasAsset) => (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!stageRect) {
+        return;
+      }
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      selectEntity({ kind: 'canvas', id: asset.id });
+      setInteraction({
+        mode: 'move',
+        assetId: asset.id,
+        pointerId: event.pointerId,
+        startPointer: { x: event.clientX, y: event.clientY },
+        initialTransform: { ...asset.transform },
+      });
+    },
+    [selectEntity, stageRect]
+  );
+
+  const startResize = React.useCallback(
+    (asset: CanvasAsset) => (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!stageRect) {
+        return;
+      }
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      setInteraction({
+        mode: 'resize',
+        assetId: asset.id,
+        pointerId: event.pointerId,
+        startPointer: { x: event.clientX, y: event.clientY },
+        initialTransform: { ...asset.transform },
+      });
+    },
+    [stageRect]
+  );
+
+  const handleNudge = React.useCallback(
+    (asset: CanvasAsset, deltaX: number, deltaY: number) => {
+      const nextX = clamp(asset.transform.x + deltaX, 0, 100 - asset.transform.width);
+      const nextY = clamp(asset.transform.y + deltaY, 0, 100 - asset.transform.height);
+      updateAssetTransform(asset.id, { x: nextX, y: nextY });
+    },
+    [updateAssetTransform]
+  );
+
   return (
-    <main className="flex flex-col flex-1 bg-[#2d2d2d] items-center justify-center p-8 overflow-hidden">
-      <div className="relative w-full h-full max-w-full max-h-full">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div 
-            className="relative w-full h-full bg-white rounded-lg shadow-2xl"
-            style={{aspectRatio: '16/9'}}
-           >
-            {/* Movable and resizable items will go here */}
-          </div>
+    <main className="flex flex-col flex-1 bg-[#2d2d2d] items-center justify-center p-4 overflow-hidden">
+      <div className="relative w-full max-w-full max-h-full flex-1 flex items-center justify-center">
+        <div
+          ref={stageRef}
+          className="relative bg-white/90 rounded-lg shadow-2xl overflow-hidden w-full max-w-5xl"
+          style={stageStyle}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+        >
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              backgroundImage:
+                'linear-gradient(45deg, rgba(0,0,0,0.08) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.08) 75%), linear-gradient(45deg, rgba(0,0,0,0.08) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.08) 75%)',
+              backgroundSize: '24px 24px',
+              backgroundPosition: '0 0,12px 12px',
+            }}
+          />
+          {assets.map((asset) => (
+            <CanvasAssetLayer
+              key={asset.id}
+              asset={asset}
+              isSelected={selectedCanvasId === asset.id}
+              onSelect={() => selectEntity({ kind: 'canvas', id: asset.id })}
+              onStartMove={startMove(asset)}
+              onStartResize={startResize(asset)}
+              onNudge={(dx, dy) => handleNudge(asset, dx, dy)}
+            />
+          ))}
+          <div className="absolute inset-0 border border-white/20 pointer-events-none rounded-lg" />
         </div>
       </div>
     </main>

--- a/components/LeftSidebar.tsx
+++ b/components/LeftSidebar.tsx
@@ -1,7 +1,8 @@
 
 import React from 'react';
-import { ASSET_CATEGORIES, TEMPLATE_FILTERS, MOCK_TEMPLATES } from '../constants';
-import type { Template } from '../types';
+import { ASSET_CATEGORIES, ASSET_DRAG_TYPE } from '../constants';
+import { useCanvasState } from '../context/CanvasStateContext';
+import type { AssetType, LibraryAsset } from '../types';
 
 type LeftSidebarProps = {
   isMobile?: boolean;
@@ -10,66 +11,173 @@ type LeftSidebarProps = {
   style?: React.CSSProperties;
 };
 
-const AssetGrid: React.FC<{ templates: Template[] }> = ({ templates }) => (
-  <div className="grid grid-cols-2 gap-3 p-4">
-    {templates.map((template) => (
-      <div key={template.id} className="relative aspect-[9/16] bg-zinc-700 rounded-lg overflow-hidden group cursor-pointer">
-        <img src={template.thumbnailUrl} alt={template.name} className="object-cover w-full h-full" />
-        <div className="absolute inset-0 bg-black bg-opacity-40 opacity-0 group-hover:opacity-100 transition-opacity"></div>
+const formatDuration = (seconds?: number) => {
+  if (!seconds) {
+    return '0:00';
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${mins}:${secs}`;
+};
+
+const AssetTile: React.FC<{
+  asset: LibraryAsset;
+  onAdd: (asset: LibraryAsset) => void;
+}> = ({ asset, onAdd }) => {
+  const handleDragStart = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.dataTransfer.effectAllowed = 'copy';
+      event.dataTransfer.setData(
+        ASSET_DRAG_TYPE,
+        JSON.stringify({ assetId: asset.id, type: asset.type })
+      );
+    },
+    [asset.id, asset.type]
+  );
+
+  return (
+    <div
+      key={asset.id}
+      className="group relative rounded-lg overflow-hidden border border-zinc-700/60 bg-zinc-800 shadow hover:shadow-lg transition-shadow"
+      draggable
+      onDragStart={handleDragStart}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <img src={asset.thumbnailUrl} alt={asset.name} className="object-cover w-full h-full" />
+        <div className="absolute inset-0 bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>
-    ))}
-  </div>
-);
+      <div className="p-3 space-y-1">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-white truncate" title={asset.name}>
+            {asset.name}
+          </h4>
+          {asset.type === 'music' && (
+            <span className="text-xs text-blue-300 font-mono">{formatDuration(asset.duration)}</span>
+          )}
+        </div>
+        {asset.type === 'music' && (
+          <p className="text-xs text-gray-400">{asset.bpm ? `${asset.bpm} BPM` : 'Loop'}</p>
+        )}
+        <button
+          type="button"
+          onClick={() => onAdd(asset)}
+          className="w-full px-3 py-1.5 text-xs font-semibold uppercase tracking-wide bg-blue-600 text-white rounded-md mt-2 hover:bg-blue-500"
+        >
+          {asset.type === 'music' ? 'Add to timeline' : 'Add to canvas'}
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const LeftSidebar: React.FC<LeftSidebarProps> = ({ isMobile = false, onClose, className = '', style }) => {
-  const containerClasses = `${isMobile ? 'fixed top-14 bottom-0 left-0 z-40 w-72 max-w-[85vw] shadow-2xl lg:hidden' : 'h-full flex-shrink-0'} bg-[#252526] border-r border-zinc-700 flex flex-col ${className}`.trim();
+  const { libraryAssets, addAssetToCanvas, addMusicClip } = useCanvasState();
+  const [activeCategory, setActiveCategory] = React.useState<AssetType>('character');
+  const [search, setSearch] = React.useState('');
+
+  const filteredAssets = React.useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return libraryAssets.filter((asset) => {
+      if (asset.type !== activeCategory) {
+        return false;
+      }
+      if (!normalizedSearch) {
+        return true;
+      }
+      return asset.name.toLowerCase().includes(normalizedSearch);
+    });
+  }, [libraryAssets, activeCategory, search]);
+
+  const handleAddAsset = React.useCallback(
+    (asset: LibraryAsset) => {
+      if (asset.type === 'music') {
+        addMusicClip(asset.id);
+      } else {
+        addAssetToCanvas(asset.id);
+      }
+    },
+    [addAssetToCanvas, addMusicClip]
+  );
+
+  const containerClasses = `${
+    isMobile
+      ? 'fixed top-14 bottom-0 left-0 z-40 w-72 max-w-[85vw] shadow-2xl lg:hidden'
+      : 'h-full flex-shrink-0'
+  } bg-[#252526] border-r border-zinc-700 flex ${className}`.trim();
+
+  const currentCategory = React.useMemo(
+    () => ASSET_CATEGORIES.find((category) => category.type === activeCategory)?.name ?? 'Assets',
+    [activeCategory],
+  );
 
   return (
     <aside className={containerClasses} style={style}>
-      <div className="p-3 border-b border-zinc-700 flex flex-col space-y-3">
-        <div className="flex items-center justify-between">
-          <span className="text-sm font-semibold uppercase tracking-wide text-gray-200">Assets</span>
-          {isMobile && (
+      <nav className="w-16 h-full bg-[#1f2021] border-r border-zinc-800/70 flex flex-col items-center py-4 space-y-3">
+        {ASSET_CATEGORIES.map((category) => {
+          const isActive = category.type === activeCategory;
+          return (
             <button
+              key={category.type}
               type="button"
-              onClick={onClose}
-              className="px-2 py-1 text-xs font-medium text-gray-300 bg-zinc-800 rounded hover:bg-zinc-700"
+              onClick={() => setActiveCategory(category.type)}
+              aria-label={category.name}
+              title={category.name}
+              className={`flex items-center justify-center w-10 h-10 rounded-lg transition-all border ${
+                isActive
+                  ? 'bg-blue-600 text-white border-blue-400 shadow-inner'
+                  : 'bg-transparent text-gray-400 border-transparent hover:bg-zinc-800 hover:text-white'
+              }`}
             >
-              Close
+              <category.icon className="w-5 h-5" />
             </button>
-          )}
-        </div>
-        <div className="flex flex-col space-y-1">
-          {ASSET_CATEGORIES.map((cat) => (
-            <button
-              key={cat.name}
-              className="flex items-center space-x-3 px-3 py-2 rounded-md hover:bg-zinc-700 transition-colors text-left"
-            >
-              <cat.icon className="w-5 h-5" />
-              <span className="text-sm font-medium">{cat.name}</span>
-            </button>
-          ))}
-        </div>
-        <div className="relative">
-          <input
-            type="text"
-            placeholder="Search templates"
-            className="w-full py-2 pl-10 pr-4 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-          <div className="absolute inset-y-0 left-0 flex items-center pl-3">
-            <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+          );
+        })}
+      </nav>
+      <div className="flex-1 flex flex-col min-h-0">
+        <div className="p-4 border-b border-zinc-700 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <span className="text-xs uppercase tracking-wide text-gray-400">Asset Library</span>
+              <div className="text-sm font-semibold text-white">{currentCategory}</div>
+            </div>
+            {isMobile && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-2 py-1 text-xs font-medium text-gray-300 bg-zinc-800 rounded hover:bg-zinc-700"
+              >
+                Close
+              </button>
+            )}
+          </div>
+          <div className="relative">
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={`Search ${activeCategory}s`}
+              className="w-full py-2 pl-10 pr-3 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3">
+              <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
           </div>
         </div>
-        <div className="flex space-x-2 overflow-x-auto scrollbar-hide">
-          {TEMPLATE_FILTERS.map((filter) => (
-            <button key={filter} className="px-3 py-1 text-sm bg-zinc-700 rounded-md hover:bg-zinc-600 whitespace-nowrap flex-shrink-0">
-              {filter}
-            </button>
-          ))}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {filteredAssets.length === 0 ? (
+            <div className="text-sm text-gray-400 text-center py-12">No assets match your search.</div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3">
+              {filteredAssets.map((asset) => (
+                <AssetTile key={asset.id} asset={asset} onAdd={handleAddAsset} />
+              ))}
+            </div>
+          )}
         </div>
-      </div>
-      <div className="flex-1 overflow-y-auto">
-        <AssetGrid templates={MOCK_TEMPLATES} />
       </div>
     </aside>
   );

--- a/constants.tsx
+++ b/constants.tsx
@@ -1,159 +1,236 @@
 import React from 'react';
-import type { AssetCategory, Template, Property, Track } from './types';
+import type { AssetCategory, LibraryAsset, AudioTrack } from './types';
 
-// Icons for Header
+// Header Icons
 export const DeviceIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+  </svg>
 );
 export const RefreshIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h5M20 20v-5h-5M4 4l1.5 1.5A9 9 0 0120.5 15M20 20l-1.5-1.5A9 9 0 013.5 9" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h5M20 20v-5h-5M4 4l1.5 1.5A9 9 0 0120.5 15M20 20l-1.5-1.5A9 9 0 013.5 9" />
+  </svg>
 );
 export const FullscreenIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" />
+  </svg>
 );
 export const PanelsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h7a2 2 0 012 2v12H5a2 2 0 01-2-2V5zm11 0h5a2 2 0 012 2v5h-7V5zm0 9h7v5a2 2 0 01-2 2h-5v-7z" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h7a2 2 0 012 2v12H5a2 2 0 01-2-2V5zm11 0h5a2 2 0 012 2v5h-7V5zm0 9h7v5a2 2 0 01-2 2h-5v-7z" />
+  </svg>
 );
 export const AdjustmentsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h4M10 6h10M4 12h6M12 12h8M4 18h2M8 18h12M8 4v4M14 10v4M6 16v4" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h4M10 6h10M4 12h6M12 12h8M4 18h2M8 18h12M8 4v4M14 10v4M6 16v4" />
+  </svg>
 );
 
-
-// Icons for Left Sidebar
-const TemplatesIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" /></svg>
+// Asset category icons
+const CharacterIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 12a4 4 0 100-8 4 4 0 000 8z" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.5 21a6.5 6.5 0 0113 0" />
+  </svg>
 );
-const ElementsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z" /></svg>
+const BackgroundIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h18v14H3z" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 13l3 3 4-4 4 4" />
+  </svg>
 );
-const UploadsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" /></svg>
+const MusicIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19a3 3 0 11-6 0 3 3 0 016 0zm12-3a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
 );
-// FIX: Export TextIcon so it can be used in Timeline.tsx
-export const TextIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6h18M7 12h10M9 18h6" /></svg>
-);
-const AudioIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 6l12-3" /></svg>
+const GraphicIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6l7 12H5z" />
+  </svg>
 );
 
 export const ASSET_CATEGORIES: AssetCategory[] = [
-  { name: 'Templates', icon: TemplatesIcon },
-  { name: 'Elements', icon: ElementsIcon },
-  { name: 'Uploads', icon: UploadsIcon },
-  { name: 'Text', icon: TextIcon },
-  { name: 'Audio', icon: AudioIcon },
+  { name: 'Characters', type: 'character', icon: CharacterIcon },
+  { name: 'Backgrounds', type: 'background', icon: BackgroundIcon },
+  { name: 'Music', type: 'music', icon: MusicIcon },
+  { name: 'Graphics', type: 'graphic', icon: GraphicIcon },
 ];
 
-export const TEMPLATE_FILTERS: string[] = ['Christmas', 'Thanksgiving', 'Food', 'Veterans', 'Business'];
-
-export const MOCK_TEMPLATES: Template[] = [
-  { id: 1, name: 'Tunnel View', thumbnailUrl: 'https://picsum.photos/360/640?random=1' },
-  { id: 2, name: 'Under the Bridge', thumbnailUrl: 'https://picsum.photos/360/640?random=2' },
-  { id: 3, name: 'Apartment Building', thumbnailUrl: 'https://picsum.photos/360/640?random=3' },
-  { id: 4, name: 'Hand with Grapes', thumbnailUrl: 'https://picsum.photos/360/640?random=4' },
-  { id: 5, name: 'Misty Ocean', thumbnailUrl: 'https://picsum.photos/360/640?random=5' },
-  { id: 6, name: 'Temple Spire', thumbnailUrl: 'https://picsum.photos/360/640?random=6' },
+export const LIBRARY_ASSETS: LibraryAsset[] = [
+  {
+    id: 'char-astronaut',
+    type: 'character',
+    name: 'Astronaut Alex',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1542736667-069246bdbc13?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1542736667-069246bdbc13?auto=format&fit=crop&w=720&q=80',
+  },
+  {
+    id: 'char-chef',
+    type: 'character',
+    name: 'Chef Clara',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1548943487-a2e4e43b4853?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1548943487-a2e4e43b4853?auto=format&fit=crop&w=720&q=80',
+  },
+  {
+    id: 'char-dancer',
+    type: 'character',
+    name: 'Dancer Diego',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1517849845537-4d257902454a?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1517849845537-4d257902454a?auto=format&fit=crop&w=720&q=80',
+  },
+  {
+    id: 'bg-city-sunset',
+    type: 'background',
+    name: 'City Sunset',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1280&q=80',
+  },
+  {
+    id: 'bg-studio',
+    type: 'background',
+    name: 'Studio Lights',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1526948128573-703ee1aeb6fa?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1526948128573-703ee1aeb6fa?auto=format&fit=crop&w=1280&q=80',
+  },
+  {
+    id: 'bg-mountain',
+    type: 'background',
+    name: 'Mountain Morning',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1280&q=80',
+  },
+  {
+    id: 'music-chill',
+    type: 'music',
+    name: 'Chill Breeze',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://samplelib.com/lib/preview/mp3/sample-3s.mp3',
+    duration: 120,
+    bpm: 90,
+  },
+  {
+    id: 'music-upbeat',
+    type: 'music',
+    name: 'Upbeat Energy',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1511379938547-c1f69419868d?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://samplelib.com/lib/preview/mp3/sample-6s.mp3',
+    duration: 150,
+    bpm: 128,
+  },
+  {
+    id: 'music-piano',
+    type: 'music',
+    name: 'Piano Reflections',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1485579149621-3123dd979885?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://samplelib.com/lib/preview/mp3/sample-12s.mp3',
+    duration: 180,
+    bpm: 72,
+  },
+  {
+    id: 'graphic-starburst',
+    type: 'graphic',
+    name: 'Starburst Overlay',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1526481280695-3c4697e2db87?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1526481280695-3c4697e2db87?auto=format&fit=crop&w=720&q=80',
+  },
+  {
+    id: 'graphic-confetti',
+    type: 'graphic',
+    name: 'Confetti Trail',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=720&q=80',
+  },
+  {
+    id: 'graphic-frame',
+    type: 'graphic',
+    name: 'Neon Frame',
+    thumbnailUrl: 'https://images.unsplash.com/photo-1526312426976-f4d754fa9bd6?auto=format&fit=crop&w=360&q=80',
+    mediaUrl: 'https://images.unsplash.com/photo-1526312426976-f4d754fa9bd6?auto=format&fit=crop&w=720&q=80',
+  },
 ];
 
-// Data for Right Sidebar
-export const PROPERTIES_TABS: string[] = ['Properties', 'Effect Controls', 'Essential Sound', 'Lumetri Color'];
+export const ASSET_DRAG_TYPE = 'application/x-vid-asset';
 
-export const PropertyGroup: { title: string; properties: Property[] }[] = [
-    {
-        title: 'Transform',
-        properties: [
-            { label: 'Position', value: '960 X   544 Y' },
-            { label: 'Anchor point', value: '960 X   544 Y' },
-            { label: 'Scale', value: '117 %   100 %', isLinked: true },
-            { label: 'Rotation', value: '0°' },
-            { label: 'Opacity', value: '100 %' },
-        ],
-    },
-    {
-        title: 'Crop',
-        properties: [
-            { label: 'Left', value: '0.0 %' },
-            { label: 'Top', value: '0.0 %' },
-            { label: 'Right', value: '0.0 %' },
-            { label: 'Bottom', value: '0.0 %' },
-        ],
-    },
+export const DEFAULT_AUDIO_TRACKS: AudioTrack[] = [
+  { id: 'A1', clips: [], muted: false, solo: false },
+  { id: 'A2', clips: [], muted: false, solo: false },
 ];
 
-// Icons for Timeline
+// Timeline icons
 export const SelectToolIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M7.72,2.95C7.54,2.53 7.2,2.2 6.79,2.05L6.78,2.05C6.18,1.83 5.49,2.04 5.12,2.58L2.23,6.9C1.94,7.34 2.03,7.94 2.4,8.32L2.4,8.32L8.53,14.45C8.92,14.83 9.51,14.93 9.95,14.64L14.28,11.75C14.82,11.38 15.03,10.69 14.81,10.09L14.81,10.08L12.91,5.16C12.7,4.56 12.06,4.17 11.43,4.17H9.25L7.72,2.95Z"/></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M7.72,2.95C7.54,2.53 7.2,2.2 6.79,2.05L6.78,2.05C6.18,1.83 5.49,2.04 5.12,2.58L2.23,6.9C1.94,7.34 2.03,7.94 2.4,8.32L2.4,8.32L8.53,14.45C8.92,14.83 9.51,14.93 9.95,14.64L14.28,11.75C14.82,11.38 15.03,10.69 14.81,10.09L14.81,10.08L12.91,5.16C12.7,4.56 12.06,4.17 11.43,4.17H9.25L7.72,2.95Z" />
+  </svg>
 );
 export const RazorToolIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.41,8.66L13,10.07L15.59,12.66L18.17,10.07L16.76,8.66M5,18L10.07,12.93L12.66,15.51L7.59,20.59H5V18M9.24,5.24L12,8L10.07,9.93L7.34,7.2L9.24,5.24M5.83,11.5L3.24,8.91L4.66,7.5L7.24,10.09L5.83,11.5Z" /></svg>
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.41,8.66L13,10.07L15.59,12.66L18.17,10.07L16.76,8.66M5,18L10.07,12.93L12.66,15.51L7.59,20.59H5V18M9.24,5.24L12,8L10.07,9.93L7.34,7.2L9.24,5.24M5.83,11.5L3.24,8.91L4.66,7.5L7.24,10.09L5.83,11.5Z" />
+  </svg>
 );
-
+export const TextIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6h18M7 12h10M9 18h6" />
+  </svg>
+);
 export const SkipStartIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M16,16.5V7.5L11,12M7,18V6H5V18H7Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M16,16.5V7.5L11,12M7,18V6H5V18H7Z" />
+  </svg>
 );
 export const StepBackwardIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M18,15.5V8.5H16V15.5H18M14,15.5V8.5L8.5,12L14,15.5Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18,15.5V8.5H16V15.5H18M14,15.5V8.5L8.5,12L14,15.5Z" />
+  </svg>
 );
 export const PlayIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M8,5.14V19.14L19,12.14L8,5.14Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M8,5.14V19.14L19,12.14L8,5.14Z" />
+  </svg>
 );
 export const StepForwardIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M6,15.5V8.5H8V15.5H6M10,15.5V8.5L15.5,12L10,15.5Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M6,15.5V8.5H8V15.5H6M10,15.5V8.5L15.5,12L10,15.5Z" />
+  </svg>
 );
 export const SkipEndIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M8,7.5V16.5L13,12M17,6V18H19V6H17Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M8,7.5V16.5L13,12M17,6V18H19V6H17Z" />
+  </svg>
 );
 export const PlusIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+  </svg>
 );
 export const MagnetIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M3,7V13A4,4 0 0,0 7,17H8V21L12,18L16,21V17H17A4,4 0 0,0 21,13V7H17V13H18V7H15V13H16V7H8V13H9V7H6V13H7V7H3Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M3,7V13A4,4 0 0,0 7,17H8V21L12,18L16,21V17H17A4,4 0 0,0 21,13V7H17V13H18V7H15V13H16V7H8V13H9V7H6V13H7V7H3Z" />
+  </svg>
 );
 export const LinkIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M17,18H15V16H17M13,18H11V16H13M9,18H7V16H9M13.5,13H11.5L10.5,15H8.5L12.5,7L16.5,15H14.5L13.5,13M13,11.3L12,9L11,11.3H13Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M17,18H15V16H17M13,18H11V16H13M9,18H7V16H9M13.5,13H11.5L10.5,15H8.5L12.5,7L16.5,15H14.5L13.5,13M13,11.3L12,9L11,11.3H13Z" />
+  </svg>
 );
-
 export const EyeIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z" />
+  </svg>
 );
 export const LockIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z" />
+  </svg>
 );
 export const MicIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-    <svg {...props} viewBox="0 0 24 24" fill="currentColor"><path d="M12,2A3,3 0 0,1 15,5V11A3,3 0 0,1 12,14A3,3 0 0,1 9,11V5A3,3 0 0,1 12,2M19,11C19,14.53 16.39,17.44 13,17.93V21H11V17.93C7.61,17.44 5,14.53 5,11H7A5,5 0 0,0 12,16A5,5 0 0,0 17,11H19Z" /></svg>
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12,2A3,3 0 0,1 15,5V11A3,3 0 0,1 12,14A3,3 0 0,1 9,11V5A3,3 0 0,1 12,2M19,11C19,14.53 16.39,17.44 13,17.93V21H11V17.93C7.61,17.44 5,14.53 5,11H7A5,5 0 0,0 12,16A5,5 0 0,0 17,11H19Z" />
+  </svg>
 );
 
+export const TIMELINE_DURATION = 300; // seconds
 
-// Data for Timeline
-export const TIMELINE_TRACKS: Track[] = [
-    {
-        id: 'V2',
-        type: 'video',
-        clips: [],
-        locked: false,
-    },
-    {
-        id: 'V1',
-        type: 'video',
-        clips: [
-            { id: 'v1-1', name: 'us-flag.mp4', type: 'video', start: 40, duration: 150, source: '' }
-        ],
-        locked: true,
-    },
-    {
-        id: 'A1',
-        type: 'audio',
-        clips: [
-            { id: 'a1-1', name: 'upbeat-music.mp3', type: 'audio', start: 30, duration: 180, source: '' }
-        ],
-        muted: false,
-    },
-    {
-        id: 'A2',
-        type: 'audio',
-        clips: [],
-        muted: true,
-        solo: false,
-    }
-];

--- a/context/CanvasStateContext.tsx
+++ b/context/CanvasStateContext.tsx
@@ -1,0 +1,344 @@
+import React from 'react';
+import {
+  ASSET_DRAG_TYPE,
+  DEFAULT_AUDIO_TRACKS,
+  LIBRARY_ASSETS,
+  TIMELINE_DURATION,
+} from '../constants';
+import type {
+  AssetType,
+  AudioClip,
+  AudioTrack,
+  CanvasAsset,
+  LibraryAsset,
+  SelectedEntity,
+  Transform,
+} from '../types';
+
+const CANVAS_STAGE_SIZE = { width: 100, height: 100 };
+
+const createId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `id-${Math.random().toString(36).slice(2, 9)}`;
+
+const cloneTracks = (tracks: AudioTrack[]): AudioTrack[] =>
+  tracks.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }));
+
+interface CanvasStateContextValue {
+  assets: CanvasAsset[];
+  audioTracks: AudioTrack[];
+  libraryAssets: LibraryAsset[];
+  selected: SelectedEntity;
+  selectEntity: (entity: SelectedEntity) => void;
+  addAssetToCanvas: (
+    assetId: string,
+    options?: { position?: { x: number; y: number }; size?: { width: number; height: number } }
+  ) => void;
+  addMusicClip: (assetId: string, options?: { start?: number; trackIndex?: number }) => void;
+  updateAssetTransform: (assetId: string, updates: Partial<Transform>) => void;
+  toggleAssetVisibility: (assetId: string) => void;
+  toggleAssetLock: (assetId: string) => void;
+  removeEntity: (entity: SelectedEntity) => void;
+  reorderAssetZIndex: (assetId: string, direction: 1 | -1) => void;
+  updateAudioClip: (clipId: string, updates: Partial<AudioClip>) => void;
+  timelineDuration: number;
+}
+
+const CanvasStateContext = React.createContext<CanvasStateContextValue | undefined>(undefined);
+
+export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [assets, setAssets] = React.useState<CanvasAsset[]>([]);
+  const [audioTracks, setAudioTracks] = React.useState<AudioTrack[]>(() =>
+    DEFAULT_AUDIO_TRACKS.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }))
+  );
+  const [selected, setSelected] = React.useState<SelectedEntity>(null);
+
+  const libraryLookup = React.useMemo(() => {
+    const map = new Map<string, LibraryAsset>();
+    for (const asset of LIBRARY_ASSETS) {
+      map.set(asset.id, asset);
+    }
+    return map;
+  }, []);
+
+  const selectEntity = React.useCallback((entity: SelectedEntity) => {
+    setSelected(entity);
+  }, []);
+
+  const addAssetToCanvas = React.useCallback<CanvasStateContextValue['addAssetToCanvas']>(
+    (assetId, options = {}) => {
+      const libraryAsset = libraryLookup.get(assetId);
+      if (!libraryAsset || libraryAsset.type === 'music') {
+        return;
+      }
+
+      const baseTransform: Transform = {
+        x: 25,
+        y: 25,
+        width: 35,
+        height: 35,
+        rotation: 0,
+        opacity: 1,
+        preserveAspectRatio: true,
+      };
+
+      if (libraryAsset.type === 'background') {
+        baseTransform.x = 0;
+        baseTransform.y = 0;
+        baseTransform.width = CANVAS_STAGE_SIZE.width;
+        baseTransform.height = CANVAS_STAGE_SIZE.height;
+        baseTransform.preserveAspectRatio = false;
+      }
+
+      if (options.position && libraryAsset.type !== 'background') {
+        baseTransform.x = options.position.x;
+        baseTransform.y = options.position.y;
+      }
+
+      if (options.size && libraryAsset.type !== 'background') {
+        baseTransform.width = options.size.width;
+        baseTransform.height = options.size.height;
+      }
+
+      const createdId = createId();
+
+      setAssets((prev) => [
+        ...prev,
+        {
+          id: createdId,
+          assetId: libraryAsset.id,
+          name: libraryAsset.name,
+          type: libraryAsset.type as Exclude<AssetType, 'music'>,
+          mediaUrl: libraryAsset.mediaUrl,
+          thumbnailUrl: libraryAsset.thumbnailUrl,
+          transform: baseTransform,
+          zIndex: prev.length + 1,
+          isLocked: false,
+          isVisible: true,
+        },
+      ]);
+
+      setSelected({ kind: 'canvas', id: createdId });
+    },
+    [libraryLookup]
+  );
+
+  const addMusicClip = React.useCallback<CanvasStateContextValue['addMusicClip']>(
+    (assetId, options = {}) => {
+      const libraryAsset = libraryLookup.get(assetId);
+      if (!libraryAsset || libraryAsset.type !== 'music') {
+        return;
+      }
+
+      const clipId = createId();
+
+      setAudioTracks((prev) => {
+        const tracks = cloneTracks(prev);
+        const duration = libraryAsset.duration ?? 120;
+        const desiredTrack =
+          typeof options.trackIndex === 'number' ? options.trackIndex : tracks.findIndex(() => true);
+        const trackIndex = desiredTrack >= 0 ? desiredTrack : 0;
+        const track = tracks[trackIndex] ?? tracks[0];
+
+        if (!track) {
+          return prev;
+        }
+
+        const start = Math.max(0, Math.min(options.start ?? 0, TIMELINE_DURATION - 1));
+        const clip: AudioClip = {
+          id: clipId,
+          assetId: libraryAsset.id,
+          name: libraryAsset.name,
+          start,
+          duration: Math.min(duration, TIMELINE_DURATION - start),
+          source: libraryAsset.mediaUrl,
+          volume: 0.8,
+          fadeIn: 0,
+          fadeOut: 0,
+        };
+
+        track.clips.push(clip);
+        tracks[trackIndex] = { ...track, clips: [...track.clips] };
+        return tracks;
+      });
+
+      setSelected({ kind: 'audio', id: clipId });
+    },
+    [libraryLookup]
+  );
+
+  const updateAssetTransform = React.useCallback<CanvasStateContextValue['updateAssetTransform']>((assetId, updates) => {
+    setAssets((prev) =>
+      prev.map((asset) =>
+        asset.id === assetId
+          ? {
+              ...asset,
+              transform: {
+                ...asset.transform,
+                ...updates,
+              },
+            }
+          : asset
+      )
+    );
+  }, []);
+
+  const toggleAssetVisibility = React.useCallback<CanvasStateContextValue['toggleAssetVisibility']>((assetId) => {
+    setAssets((prev) =>
+      prev.map((asset) =>
+        asset.id === assetId
+          ? {
+              ...asset,
+              isVisible: !asset.isVisible,
+            }
+          : asset
+      )
+    );
+  }, []);
+
+  const toggleAssetLock = React.useCallback<CanvasStateContextValue['toggleAssetLock']>((assetId) => {
+    setAssets((prev) =>
+      prev.map((asset) =>
+        asset.id === assetId
+          ? {
+              ...asset,
+              isLocked: !asset.isLocked,
+            }
+          : asset
+      )
+    );
+  }, []);
+
+  const reorderAssetZIndex = React.useCallback<CanvasStateContextValue['reorderAssetZIndex']>((assetId, direction) => {
+    setAssets((prev) => {
+      const next = [...prev];
+      const index = next.findIndex((asset) => asset.id === assetId);
+      if (index === -1) {
+        return prev;
+      }
+
+      const swapIndex = index + direction;
+      if (swapIndex < 0 || swapIndex >= next.length) {
+        return prev;
+      }
+
+      const temp = next[index];
+      next[index] = next[swapIndex];
+      next[swapIndex] = temp;
+
+      return next.map((asset, idx) => ({ ...asset, zIndex: idx + 1 }));
+    });
+  }, []);
+
+  const updateAudioClip = React.useCallback<CanvasStateContextValue['updateAudioClip']>((clipId, updates) => {
+    setAudioTracks((prev) => {
+      const tracks = cloneTracks(prev);
+
+      for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
+        const track = tracks[trackIndex];
+        const clipIndex = track.clips.findIndex((clip) => clip.id === clipId);
+        if (clipIndex !== -1) {
+          const clip = track.clips[clipIndex];
+          const nextClip = {
+            ...clip,
+            ...updates,
+          };
+
+          nextClip.start = Math.max(0, Math.min(nextClip.start, TIMELINE_DURATION - 1));
+          nextClip.duration = Math.max(1, Math.min(nextClip.duration, TIMELINE_DURATION - nextClip.start));
+
+          track.clips[clipIndex] = nextClip;
+          tracks[trackIndex] = { ...track, clips: [...track.clips] };
+          return tracks;
+        }
+      }
+
+      return prev;
+    });
+  }, []);
+
+  const removeEntity = React.useCallback<CanvasStateContextValue['removeEntity']>((entity) => {
+    if (!entity) {
+      return;
+    }
+
+    if (entity.kind === 'canvas') {
+      setAssets((prev) => prev.filter((asset) => asset.id !== entity.id));
+    } else if (entity.kind === 'audio') {
+      setAudioTracks((prev) => {
+        const tracks = cloneTracks(prev);
+        for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
+          const track = tracks[trackIndex];
+          const nextClips = track.clips.filter((clip) => clip.id !== entity.id);
+          tracks[trackIndex] = { ...track, clips: nextClips };
+        }
+        return tracks;
+      });
+    }
+
+    setSelected(null);
+  }, []);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.key === 'Delete' || event.key === 'Backspace') && selected) {
+        event.preventDefault();
+        removeEntity(selected);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [removeEntity, selected]);
+
+  const value = React.useMemo<CanvasStateContextValue>(
+    () => ({
+      assets,
+      audioTracks,
+      libraryAssets: LIBRARY_ASSETS,
+      selected,
+      selectEntity,
+      addAssetToCanvas,
+      addMusicClip,
+      updateAssetTransform,
+      toggleAssetVisibility,
+      toggleAssetLock,
+      removeEntity,
+      reorderAssetZIndex,
+      updateAudioClip,
+      timelineDuration: TIMELINE_DURATION,
+    }),
+    [
+      assets,
+      audioTracks,
+      selected,
+      selectEntity,
+      addAssetToCanvas,
+      addMusicClip,
+      updateAssetTransform,
+      toggleAssetVisibility,
+      toggleAssetLock,
+      removeEntity,
+      reorderAssetZIndex,
+      updateAudioClip,
+    ]
+  );
+
+  return <CanvasStateContext.Provider value={value}>{children}</CanvasStateContext.Provider>;
+};
+
+export const useCanvasState = (): CanvasStateContextValue => {
+  const context = React.useContext(CanvasStateContext);
+  if (!context) {
+    throw new Error('useCanvasState must be used within a CanvasStateProvider');
+  }
+  return context;
+};
+
+export const useLibraryAsset = (assetId: string): LibraryAsset | undefined => {
+  const { libraryAssets } = useCanvasState();
+  return React.useMemo(() => libraryAssets.find((asset) => asset.id === assetId), [libraryAssets, assetId]);
+};
+
+export { ASSET_DRAG_TYPE };

--- a/types.ts
+++ b/types.ts
@@ -1,37 +1,71 @@
 
 import type React from 'react';
 
+export type AssetType = 'character' | 'background' | 'music' | 'graphic';
+
 export interface AssetCategory {
   name: string;
+  type: AssetType;
   icon: React.FC<React.SVGProps<SVGSVGElement>>;
 }
 
-export interface Template {
-  id: number;
+export interface LibraryAsset {
+  id: string;
+  type: AssetType;
   name: string;
   thumbnailUrl: string;
+  mediaUrl: string;
+  duration?: number;
+  bpm?: number;
 }
 
-export interface Property {
-    label: string;
-    value: string;
-    isLinked?: boolean;
+export interface Transform {
+  /** Left position as percentage of the canvas width */
+  x: number;
+  /** Top position as percentage of the canvas height */
+  y: number;
+  /** Width as percentage of the canvas width */
+  width: number;
+  /** Height as percentage of the canvas height */
+  height: number;
+  rotation: number;
+  opacity: number;
+  preserveAspectRatio?: boolean;
 }
 
-export interface Clip {
-    id: string;
-    name: string;
-    type: 'video' | 'audio';
-    start: number;
-    duration: number;
-    source: string;
+export interface CanvasAsset {
+  id: string;
+  assetId: string;
+  type: Exclude<AssetType, 'music'>;
+  name: string;
+  mediaUrl: string;
+  thumbnailUrl?: string;
+  transform: Transform;
+  zIndex: number;
+  isLocked: boolean;
+  isVisible: boolean;
 }
 
-export interface Track {
-    id: string;
-    type: 'video' | 'audio';
-    clips: Clip[];
-    muted?: boolean;
-    solo?: boolean;
-    locked?: boolean;
+export interface AudioClip {
+  id: string;
+  assetId: string;
+  name: string;
+  start: number;
+  duration: number;
+  source: string;
+  volume: number;
+  fadeIn?: number;
+  fadeOut?: number;
 }
+
+export interface AudioTrack {
+  id: string;
+  clips: AudioClip[];
+  muted?: boolean;
+  solo?: boolean;
+}
+
+export type SelectedEntity =
+  | { kind: 'canvas'; id: string }
+  | { kind: 'audio'; id: string }
+  | null;


### PR DESCRIPTION
## Summary
- restructure the asset library sidebar to include a dedicated full-height icon rail for category selection
- surface the active category label above the search panel while preserving existing asset filtering and add-to-canvas controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0499d9fb88325a45aa54365a3faf4