### PR TITLE
Align canvas layers with timeline tracks

### DIFF
--- a/components/CenterPanel.tsx
+++ b/components/CenterPanel.tsx
@@ -56,6 +56,7 @@ const CanvasAssetLayer: React.FC<{
     transform: `rotate(${asset.transform.rotation}deg)`,
     opacity: asset.transform.opacity,
     zIndex,
+    pointerEvents: isEditable ? 'auto' : 'none',
   };
 
   return (

--- a/components/CenterPanel.tsx
+++ b/components/CenterPanel.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { ASSET_DRAG_TYPE } from '../constants';
 import { useCanvasState } from '../context/CanvasStateContext';
-import type { CanvasAsset } from '../types';
+import type { CanvasAsset, TimelineMode } from '../types';
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
@@ -17,10 +17,35 @@ const CanvasAssetLayer: React.FC<{
   onStartMove: (event: React.PointerEvent<HTMLDivElement>) => void;
   onStartResize: (event: React.PointerEvent<HTMLButtonElement>) => void;
   onNudge: (deltaX: number, deltaY: number) => void;
-}> = ({ asset, isSelected, onSelect, onStartMove, onStartResize, onNudge }) => {
-  if (!asset.isVisible) {
+  mode: TimelineMode;
+  currentTime: number;
+  isTrackHidden: boolean;
+  zIndex: number;
+}> = ({
+  asset,
+  isSelected,
+  onSelect,
+  onStartMove,
+  onStartResize,
+  onNudge,
+  mode,
+  currentTime,
+  isTrackHidden,
+  zIndex,
+}) => {
+  if (!asset.isVisible || isTrackHidden) {
     return null;
   }
+
+  const isTimelineActive = asset.timeline
+    ? currentTime >= asset.timeline.start && currentTime < asset.timeline.start + asset.timeline.duration
+    : true;
+
+  if (!isTimelineActive) {
+    return null;
+  }
+
+  const isEditable = mode === 'edit' && !asset.isLocked;
 
   const style: React.CSSProperties = {
     position: 'absolute',
@@ -30,6 +55,7 @@ const CanvasAssetLayer: React.FC<{
     height: `${asset.transform.height}%`,
     transform: `rotate(${asset.transform.rotation}deg)`,
     opacity: asset.transform.opacity,
+    zIndex,
   };
 
   return (
@@ -37,7 +63,7 @@ const CanvasAssetLayer: React.FC<{
       role="button"
       tabIndex={0}
       onPointerDown={(event) => {
-        if (asset.isLocked) {
+        if (!isEditable) {
           return;
         }
         (event.currentTarget as HTMLDivElement).focus();
@@ -45,7 +71,7 @@ const CanvasAssetLayer: React.FC<{
         onStartMove(event);
       }}
       onKeyDown={(event) => {
-        if (!isSelected || asset.isLocked) {
+        if (!isSelected || !isEditable) {
           return;
         }
         const step = event.shiftKey ? 5 : 1;
@@ -67,10 +93,10 @@ const CanvasAssetLayer: React.FC<{
         }
       }}
       style={style}
-      className={`group cursor-${asset.isLocked ? 'not-allowed' : 'move'} focus:outline-none`}
+      className={`group ${isEditable ? 'cursor-move' : 'cursor-default'} focus:outline-none`}
     >
       <img src={asset.mediaUrl} alt={asset.name} className="w-full h-full object-cover rounded shadow" draggable={false} />
-      {isSelected && !asset.isLocked && (
+      {isSelected && isEditable && (
         <>
           <div className="absolute inset-0 border-2 border-blue-400 rounded pointer-events-none" />
           <button
@@ -96,6 +122,9 @@ const CenterPanel: React.FC = () => {
     selectEntity,
     selected,
     updateAssetTransform,
+    contentTracks,
+    currentTime,
+    mode,
   } = useCanvasState();
   const stageRef = React.useRef<HTMLDivElement>(null);
   const [stageRect, setStageRect] = React.useState<DOMRect | null>(null);
@@ -123,7 +152,10 @@ const CenterPanel: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (!interaction) {
+    if (!interaction || mode !== 'edit') {
+      if (interaction && mode !== 'edit') {
+        setInteraction(null);
+      }
       return;
     }
 
@@ -177,13 +209,13 @@ const CenterPanel: React.FC = () => {
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [interaction, stageRect, updateAssetTransform]);
+  }, [interaction, mode, stageRect, updateAssetTransform]);
 
   const handleDrop = React.useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
       event.stopPropagation();
-      if (!stageRect) {
+      if (!stageRect || mode !== 'edit') {
         return;
       }
       const data = event.dataTransfer.getData(ASSET_DRAG_TYPE);
@@ -208,15 +240,15 @@ const CenterPanel: React.FC = () => {
         // ignore malformed payloads
       }
     },
-    [addAssetToCanvas, stageRect]
+    [addAssetToCanvas, mode, stageRect]
   );
 
   const handleDragOver = React.useCallback((event: React.DragEvent) => {
-    if (event.dataTransfer.types.includes(ASSET_DRAG_TYPE)) {
+    if (mode === 'edit' && event.dataTransfer.types.includes(ASSET_DRAG_TYPE)) {
       event.preventDefault();
       event.dataTransfer.dropEffect = 'copy';
     }
-  }, []);
+  }, [mode]);
 
   const selectedCanvasId = selected?.kind === 'canvas' ? selected.id : null;
 
@@ -224,7 +256,7 @@ const CenterPanel: React.FC = () => {
     (asset: CanvasAsset) => (event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      if (!stageRect) {
+      if (!stageRect || mode !== 'edit' || asset.isLocked) {
         return;
       }
       event.currentTarget.setPointerCapture?.(event.pointerId);
@@ -237,14 +269,14 @@ const CenterPanel: React.FC = () => {
         initialTransform: { ...asset.transform },
       });
     },
-    [selectEntity, stageRect]
+    [mode, selectEntity, stageRect]
   );
 
   const startResize = React.useCallback(
     (asset: CanvasAsset) => (event: React.PointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      if (!stageRect) {
+      if (!stageRect || mode !== 'edit' || asset.isLocked) {
         return;
       }
       event.currentTarget.setPointerCapture?.(event.pointerId);
@@ -256,17 +288,54 @@ const CenterPanel: React.FC = () => {
         initialTransform: { ...asset.transform },
       });
     },
-    [stageRect]
+    [mode, stageRect]
   );
 
   const handleNudge = React.useCallback(
     (asset: CanvasAsset, deltaX: number, deltaY: number) => {
+      if (mode !== 'edit' || asset.isLocked) {
+        return;
+      }
       const nextX = clamp(asset.transform.x + deltaX, 0, 100 - asset.transform.width);
       const nextY = clamp(asset.transform.y + deltaY, 0, 100 - asset.transform.height);
       updateAssetTransform(asset.id, { x: nextX, y: nextY });
     },
-    [updateAssetTransform]
+    [mode, updateAssetTransform]
   );
+
+  const hiddenTracks = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const track of contentTracks) {
+      if (track.hidden) {
+        ids.add(track.id);
+      }
+    }
+    return ids;
+  }, [contentTracks]);
+
+  const assetLayerOrder = React.useMemo(() => {
+    const trackPriority = new Map<string, number>();
+    const totalTracks = contentTracks.length;
+
+    contentTracks.forEach((track, index) => {
+      trackPriority.set(track.id, totalTracks - index);
+    });
+
+    return assets
+      .map((asset) => {
+        const timelineMeta = asset.timeline;
+
+        const priorityFromTrack = timelineMeta ? trackPriority.get(timelineMeta.trackId) ?? 0 : 0;
+        const nonTimelineBoost = timelineMeta ? 0 : totalTracks + 1;
+        const backgroundPenalty = asset.type === 'background' ? -1 : 0;
+
+        const computedZIndex =
+          (priorityFromTrack + nonTimelineBoost + backgroundPenalty) * 1000 + (asset.zIndex ?? 0);
+
+        return { asset, computedZIndex };
+      })
+      .sort((a, b) => a.computedZIndex - b.computedZIndex);
+  }, [assets, contentTracks]);
 
   return (
     <main className="flex flex-col flex-1 bg-[#2d2d2d] items-center justify-center p-4 overflow-hidden">
@@ -287,7 +356,7 @@ const CenterPanel: React.FC = () => {
               backgroundPosition: '0 0,12px 12px',
             }}
           />
-          {assets.map((asset) => (
+          {assetLayerOrder.map(({ asset, computedZIndex }) => (
             <CanvasAssetLayer
               key={asset.id}
               asset={asset}
@@ -296,6 +365,10 @@ const CenterPanel: React.FC = () => {
               onStartMove={startMove(asset)}
               onStartResize={startResize(asset)}
               onNudge={(dx, dy) => handleNudge(asset, dx, dy)}
+              mode={mode}
+              currentTime={currentTime}
+              isTrackHidden={asset.timeline ? hiddenTracks.has(asset.timeline.trackId) : false}
+              zIndex={computedZIndex}
             />
           ))}
           <div className="absolute inset-0 border border-white/20 pointer-events-none rounded-lg" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,7 @@ import {
   PanelsIcon,
   AdjustmentsIcon,
 } from '../constants';
+import { useCanvasState } from '../context/CanvasStateContext';
 
 type HeaderProps = {
   isMobile: boolean;
@@ -17,6 +18,18 @@ type HeaderProps = {
 };
 
 const Header: React.FC<HeaderProps> = ({ isMobile, onToggleLeft, onToggleRight, leftOpen, rightOpen }) => {
+  const { mode, setMode, isPlaying, pause } = useCanvasState();
+
+  const handleSetMode = React.useCallback(
+    (nextMode: 'edit' | 'play') => {
+      if (nextMode === 'edit' && isPlaying) {
+        pause();
+      }
+      setMode(nextMode);
+    },
+    [isPlaying, pause, setMode]
+  );
+
   return (
     <header className="flex items-center justify-between h-14 px-4 bg-[#252526] border-b border-zinc-700 flex-shrink-0 z-40">
       <div className="flex items-center space-x-3">
@@ -41,8 +54,24 @@ const Header: React.FC<HeaderProps> = ({ isMobile, onToggleLeft, onToggleRight, 
           </div>
         )}
         <div className="hidden sm:flex items-center bg-zinc-700 rounded-md p-0.5">
-          <button className="px-3 py-1 text-sm bg-zinc-800 rounded-sm">Preview</button>
-          <button className="px-3 py-1 text-sm text-gray-400">Code</button>
+          <button
+            type="button"
+            onClick={() => handleSetMode('edit')}
+            className={`px-3 py-1 text-sm rounded-sm font-semibold ${
+              mode === 'edit' ? 'bg-zinc-800 text-white' : 'text-gray-300'
+            }`}
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => handleSetMode('play')}
+            className={`px-3 py-1 text-sm font-semibold rounded-sm ${
+              mode === 'play' ? 'bg-zinc-800 text-white' : 'text-gray-300'
+            }`}
+          >
+            Play
+          </button>
         </div>
         <button className="hidden md:flex items-center space-x-2 px-3 py-1 text-sm text-gray-400 hover:text-white">
           <FullscreenIcon className="w-4 h-4" />

--- a/components/LeftSidebar.tsx
+++ b/components/LeftSidebar.tsx
@@ -25,23 +25,28 @@ const formatDuration = (seconds?: number) => {
 const AssetTile: React.FC<{
   asset: LibraryAsset;
   onAdd: (asset: LibraryAsset) => void;
-}> = ({ asset, onAdd }) => {
+  disabled?: boolean;
+}> = ({ asset, onAdd, disabled = false }) => {
   const handleDragStart = React.useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
       event.dataTransfer.effectAllowed = 'copy';
       event.dataTransfer.setData(
         ASSET_DRAG_TYPE,
         JSON.stringify({ assetId: asset.id, type: asset.type })
       );
     },
-    [asset.id, asset.type]
+    [asset.id, asset.type, disabled]
   );
 
   return (
     <div
       key={asset.id}
       className="group relative rounded-lg overflow-hidden border border-zinc-700/60 bg-zinc-800 shadow hover:shadow-lg transition-shadow"
-      draggable
+      draggable={!disabled}
       onDragStart={handleDragStart}
     >
       <div className="relative aspect-[4/3] overflow-hidden">
@@ -62,8 +67,17 @@ const AssetTile: React.FC<{
         )}
         <button
           type="button"
-          onClick={() => onAdd(asset)}
-          className="w-full px-3 py-1.5 text-xs font-semibold uppercase tracking-wide bg-blue-600 text-white rounded-md mt-2 hover:bg-blue-500"
+          onClick={() => {
+            if (!disabled) {
+              onAdd(asset);
+            }
+          }}
+          disabled={disabled}
+          className={`w-full px-3 py-1.5 text-xs font-semibold uppercase tracking-wide rounded-md mt-2 ${
+            disabled
+              ? 'bg-zinc-600 text-gray-400 cursor-not-allowed'
+              : 'bg-blue-600 text-white hover:bg-blue-500'
+          }`}
         >
           {asset.type === 'music' ? 'Add to timeline' : 'Add to canvas'}
         </button>
@@ -73,7 +87,7 @@ const AssetTile: React.FC<{
 };
 
 const LeftSidebar: React.FC<LeftSidebarProps> = ({ isMobile = false, onClose, className = '', style }) => {
-  const { libraryAssets, addAssetToCanvas, addMusicClip } = useCanvasState();
+  const { libraryAssets, addAssetToCanvas, addMusicClip, mode } = useCanvasState();
   const [activeCategory, setActiveCategory] = React.useState<AssetType>('character');
   const [search, setSearch] = React.useState('');
 
@@ -173,7 +187,12 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({ isMobile = false, onClose, cl
           ) : (
             <div className="grid grid-cols-1 gap-3">
               {filteredAssets.map((asset) => (
-                <AssetTile key={asset.id} asset={asset} onAdd={handleAddAsset} />
+                <AssetTile
+                  key={asset.id}
+                  asset={asset}
+                  onAdd={handleAddAsset}
+                  disabled={mode !== 'edit'}
+                />
               ))}
             </div>
           )}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -8,16 +8,29 @@ import {
   PlayIcon,
   StepForwardIcon,
   SkipEndIcon,
+  PauseIcon,
   PlusIcon,
   MagnetIcon,
   LinkIcon,
   MicIcon,
+  EyeIcon,
+  LockIcon,
   ASSET_DRAG_TYPE,
 } from '../constants';
 import { useCanvasState } from '../context/CanvasStateContext';
-import type { AudioClip, AudioTrack } from '../types';
+import type { AudioClip, ContentClip, TimelineMode } from '../types';
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const formatTime = (seconds: number) => {
+  const mins = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${mins}:${secs}`;
+};
 
 const createSeededRandom = (seedString: string) => {
   let seed = 0;
@@ -46,35 +59,60 @@ const AudioWaveform: React.FC<{ seed: string }> = ({ seed }) => {
   );
 };
 
-const TimelineToolbar: React.FC = () => (
-  <div className="h-10 bg-[#2d2d2d] flex items-center justify-between px-4 border-b border-zinc-700 flex-shrink-0">
+const TimelineToolbar: React.FC<{
+  isPlaying: boolean;
+  onTogglePlay: () => void;
+  mode: TimelineMode;
+  setMode: (mode: TimelineMode) => void;
+}> = ({ isPlaying, onTogglePlay, mode, setMode }) => (
+  <div className="h-12 bg-[#2d2d2d] flex items-center justify-between px-4 border-b border-zinc-700 flex-shrink-0">
     <div className="flex items-center space-x-4">
-      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded">
+      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded" type="button">
         <MagnetIcon className="w-5 h-5" />
       </button>
-      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded">
+      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded" type="button">
         <LinkIcon className="w-5 h-5" />
       </button>
     </div>
     <div className="flex items-center space-x-2">
-      <button className="p-1.5 text-gray-400 hover:text-white">
+      <button className="p-1.5 text-gray-400 hover:text-white" type="button">
         <SkipStartIcon className="w-5 h-5" />
       </button>
-      <button className="p-1.5 text-gray-400 hover:text-white">
+      <button className="p-1.5 text-gray-400 hover:text-white" type="button">
         <StepBackwardIcon className="w-5 h-5" />
       </button>
-      <button className="p-2 text-white bg-blue-600 rounded-full hover:bg-blue-500">
-        <PlayIcon className="w-6 h-6" />
+      <button
+        className="p-2 text-white bg-blue-600 rounded-full hover:bg-blue-500"
+        type="button"
+        onClick={onTogglePlay}
+      >
+        {isPlaying ? <PauseIcon className="w-6 h-6" /> : <PlayIcon className="w-6 h-6" />}
       </button>
-      <button className="p-1.5 text-gray-400 hover:text-white">
+      <button className="p-1.5 text-gray-400 hover:text-white" type="button">
         <StepForwardIcon className="w-5 h-5" />
       </button>
-      <button className="p-1.5 text-gray-400 hover:text-white">
+      <button className="p-1.5 text-gray-400 hover:text-white" type="button">
         <SkipEndIcon className="w-5 h-5" />
       </button>
     </div>
     <div className="flex items-center space-x-4">
-      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded">
+      <div className="flex items-center bg-zinc-700 rounded-md overflow-hidden text-xs">
+        <button
+          type="button"
+          className={`px-3 py-1.5 font-semibold uppercase tracking-wide ${mode === 'edit' ? 'bg-blue-600 text-white' : 'text-gray-300'}`}
+          onClick={() => setMode('edit')}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-1.5 font-semibold uppercase tracking-wide ${mode === 'play' ? 'bg-blue-600 text-white' : 'text-gray-300'}`}
+          onClick={() => setMode('play')}
+        >
+          Play
+        </button>
+      </div>
+      <button className="p-1.5 text-gray-400 hover:text-white hover:bg-zinc-700 rounded" type="button">
         <PlusIcon className="w-5 h-5" />
       </button>
     </div>
@@ -83,112 +121,56 @@ const TimelineToolbar: React.FC = () => (
 
 const TimelineTools: React.FC = () => (
   <div className="w-12 bg-[#252526] border-r border-zinc-700 flex flex-col items-center py-2 space-y-2 flex-shrink-0">
-    <button className="p-2 text-white bg-blue-600 rounded-md">
+    <button className="p-2 text-white bg-blue-600 rounded-md" type="button">
       <SelectToolIcon className="w-6 h-6" />
     </button>
-    <button className="p-2 text-gray-400 hover:text-white rounded-md hover:bg-zinc-700">
+    <button className="p-2 text-gray-400 hover:text-white rounded-md hover:bg-zinc-700" type="button">
       <RazorToolIcon className="w-6 h-6" />
     </button>
-    <button className="p-2 text-gray-400 hover:text-white rounded-md hover:bg-zinc-700">
+    <button className="p-2 text-gray-400 hover:text-white rounded-md hover:bg-zinc-700" type="button">
       <TextIcon className="w-6 h-6" />
     </button>
   </div>
 );
 
-const findClip = (tracks: AudioTrack[], clipId: string) => {
-  for (const track of tracks) {
-    const clip = track.clips.find((item) => item.id === clipId);
-    if (clip) {
-      return clip;
-    }
-  }
-  return null;
+type DragState = {
+  mode: 'move' | 'resize-start' | 'resize-end';
+  clipId: string;
+  pointerId: number;
+  offset: number;
+  kind: 'audio' | 'content';
 };
 
-const TimelineClip: React.FC<{
-  clip: AudioClip;
-  timelineDuration: number;
-  isSelected: boolean;
-  isDragging: boolean;
-  onBodyPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
-  onResizeStart: (event: React.PointerEvent<HTMLDivElement>) => void;
-  onResizeEnd: (event: React.PointerEvent<HTMLDivElement>) => void;
-}> = ({ clip, timelineDuration, isSelected, isDragging, onBodyPointerDown, onResizeStart, onResizeEnd }) => {
-  const left = (clip.start / timelineDuration) * 100;
-  const width = (clip.duration / timelineDuration) * 100;
-
-  return (
-    <div
-      className={`absolute h-full flex items-center rounded-md overflow-hidden border border-black/40 transition-[box-shadow,transform] ${
-        isSelected ? 'ring-2 ring-blue-400' : ''
-      } ${isDragging ? 'shadow-xl scale-[1.01]' : ''}`}
-      style={{ left: `${left}%`, width: `${width}%`, height: '80%' }}
-    >
-      <div
-        role="presentation"
-        className="w-1.5 h-full bg-white/30 cursor-ew-resize"
-        onPointerDown={onResizeStart}
-      />
-      <div
-        role="button"
-        tabIndex={0}
-        onPointerDown={onBodyPointerDown}
-        className="flex-1 h-full bg-green-600/80 cursor-grab active:cursor-grabbing"
-      >
-        <div className="h-full w-full">
-          <AudioWaveform seed={clip.id} />
-        </div>
-        <div className="absolute bottom-1 left-2 right-2 text-xs text-white font-semibold truncate pointer-events-none">
-          {clip.name}
-        </div>
-      </div>
-      <div
-        role="presentation"
-        className="w-1.5 h-full bg-white/30 cursor-ew-resize"
-        onPointerDown={onResizeEnd}
-      />
-    </div>
-  );
-};
-
-const TrackHeader: React.FC<{ track: AudioTrack }> = ({ track }) => (
-  <div className="h-16 flex items-center px-2 border-b border-zinc-800 space-x-2">
-    <div className="flex-1 flex flex-col justify-center">
-      <span className="font-bold text-sm">{track.id}</span>
-      <span className="text-xs text-gray-500">Audio track</span>
-    </div>
-    <button className={`p-1 rounded w-6 h-6 text-xs font-bold ${track.muted ? 'bg-yellow-500 text-black' : 'bg-zinc-600 text-gray-300'}`}>
-      M
-    </button>
-    <button className={`p-1 rounded w-6 h-6 text-xs font-bold ${track.solo ? 'bg-green-500 text-black' : 'bg-zinc-600 text-gray-300'}`}>
-      S
-    </button>
-    <button className="p-1 text-gray-400 hover:text-red-500">
-      <MicIcon className="w-5 h-5" />
-    </button>
-  </div>
-);
-
-const clampTime = (value: number, duration: number) => clamp(value, 0, duration);
-
-const usePointerDrag = (
+const useClipDrag = (
   timelineDuration: number,
-  audioTracks: AudioTrack[],
-  updateAudioClip: (clipId: string, updates: Partial<AudioClip>) => void
+  contentTracks: ReturnType<typeof useCanvasState>['contentTracks'],
+  audioTracks: ReturnType<typeof useCanvasState>['audioTracks'],
+  updateContentClip: (clipId: string, updates: Partial<ContentClip>) => void,
+  updateAudioClip: (clipId: string, updates: Partial<AudioClip>) => void,
+  mode: TimelineMode,
+  moveContentClip: (clipId: string, trackIndex: number) => void,
+  moveAudioClip: (clipId: string, trackIndex: number) => void,
+  getContentTrackIndexFromClientY: (clientY: number) => number | null,
+  getAudioTrackIndexFromClientY: (clientY: number) => number | null
 ) => {
   const timelineContentRef = React.useRef<HTMLDivElement>(null);
-  const [dragState, setDragState] = React.useState<
-    | {
-        mode: 'move' | 'resize-start' | 'resize-end';
-        clipId: string;
-        pointerId: number;
-        offset: number;
+  const [dragState, setDragState] = React.useState<DragState | null>(null);
+
+  const getTimeFromClientX = React.useCallback(
+    (clientX: number) => {
+      const rect = timelineContentRef.current?.getBoundingClientRect();
+      if (!rect) {
+        return 0;
       }
-    | null
-  >(null);
+      const position = clamp(clientX - rect.left, 0, rect.width);
+      const ratio = rect.width === 0 ? 0 : position / rect.width;
+      return ratio * timelineDuration;
+    },
+    [timelineDuration]
+  );
 
   React.useEffect(() => {
-    if (!dragState) {
+    if (!dragState || mode !== 'edit') {
       return undefined;
     }
 
@@ -196,29 +178,84 @@ const usePointerDrag = (
       if (event.pointerId !== dragState.pointerId) {
         return;
       }
-      const trackClip = findClip(audioTracks, dragState.clipId);
-      if (!trackClip) {
-        return;
-      }
-      const timelineRect = timelineContentRef.current?.getBoundingClientRect();
-      if (!timelineRect) {
-        return;
-      }
-      const ratio = timelineRect.width === 0 ? 0 : clamp((event.clientX - timelineRect.left) / timelineRect.width, 0, 1);
-      const pointerTime = ratio * timelineDuration;
+      const pointerTime = getTimeFromClientX(event.clientX);
 
-      if (dragState.mode === 'move') {
-        const newStart = clampTime(pointerTime - dragState.offset, timelineDuration - trackClip.duration);
-        updateAudioClip(trackClip.id, { start: newStart });
-      } else if (dragState.mode === 'resize-start') {
-        const endTime = trackClip.start + trackClip.duration;
-        const newStart = clamp(pointerTime, 0, endTime - 1);
-        const newDuration = clamp(endTime - newStart, 1, timelineDuration - newStart);
-        updateAudioClip(trackClip.id, { start: newStart, duration: newDuration });
-      } else if (dragState.mode === 'resize-end') {
-        const newEnd = clamp(pointerTime, trackClip.start + 1, timelineDuration);
-        const newDuration = clamp(newEnd - trackClip.start, 1, timelineDuration - trackClip.start);
-        updateAudioClip(trackClip.id, { duration: newDuration });
+      if (dragState.kind === 'audio') {
+        let target: AudioClip | null = null;
+        let trackIndexOfClip = -1;
+        for (let trackIndex = 0; trackIndex < audioTracks.length; trackIndex += 1) {
+          const track = audioTracks[trackIndex];
+          const clip = track.clips.find((item) => item.id === dragState.clipId);
+          if (clip) {
+            target = clip;
+            trackIndexOfClip = trackIndex;
+            break;
+          }
+        }
+        if (!target) {
+          return;
+        }
+
+        if (dragState.mode === 'move') {
+          const destinationTrackIndex = getAudioTrackIndexFromClientY(event.clientY);
+          if (
+            destinationTrackIndex !== null &&
+            destinationTrackIndex !== trackIndexOfClip &&
+            !audioTracks[destinationTrackIndex]?.locked
+          ) {
+            moveAudioClip(target.id, destinationTrackIndex);
+            trackIndexOfClip = destinationTrackIndex;
+          }
+          const newStart = clamp(pointerTime - dragState.offset, 0, timelineDuration - target.duration);
+          updateAudioClip(target.id, { start: newStart });
+        } else if (dragState.mode === 'resize-start') {
+          const endTime = target.start + target.duration;
+          const newStart = clamp(pointerTime, 0, endTime - 1);
+          const newDuration = clamp(endTime - newStart, 1, timelineDuration - newStart);
+          updateAudioClip(target.id, { start: newStart, duration: newDuration });
+        } else if (dragState.mode === 'resize-end') {
+          const newEnd = clamp(pointerTime, target.start + 1, timelineDuration);
+          const newDuration = clamp(newEnd - target.start, 1, timelineDuration - target.start);
+          updateAudioClip(target.id, { duration: newDuration });
+        }
+      } else {
+        let target: ContentClip | null = null;
+        let trackIndexOfClip = -1;
+        for (let trackIndex = 0; trackIndex < contentTracks.length; trackIndex += 1) {
+          const track = contentTracks[trackIndex];
+          const clip = track.clips.find((item) => item.id === dragState.clipId);
+          if (clip) {
+            target = clip;
+            trackIndexOfClip = trackIndex;
+            break;
+          }
+        }
+        if (!target) {
+          return;
+        }
+
+        if (dragState.mode === 'move') {
+          const destinationTrackIndex = getContentTrackIndexFromClientY(event.clientY);
+          if (
+            destinationTrackIndex !== null &&
+            destinationTrackIndex !== trackIndexOfClip &&
+            !contentTracks[destinationTrackIndex]?.locked
+          ) {
+            moveContentClip(target.id, destinationTrackIndex);
+            trackIndexOfClip = destinationTrackIndex;
+          }
+          const newStart = clamp(pointerTime - dragState.offset, 0, timelineDuration - target.duration);
+          updateContentClip(target.id, { start: newStart });
+        } else if (dragState.mode === 'resize-start') {
+          const endTime = target.start + target.duration;
+          const newStart = clamp(pointerTime, 0, endTime - 1);
+          const newDuration = clamp(endTime - newStart, 1, timelineDuration - newStart);
+          updateContentClip(target.id, { start: newStart, duration: newDuration });
+        } else if (dragState.mode === 'resize-end') {
+          const newEnd = clamp(pointerTime, target.start + 1, timelineDuration);
+          const newDuration = clamp(newEnd - target.start, 1, timelineDuration - target.start);
+          updateContentClip(target.id, { duration: newDuration });
+        }
       }
     };
 
@@ -234,62 +271,393 @@ const usePointerDrag = (
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [audioTracks, dragState, timelineDuration, updateAudioClip]);
+  }, [
+    audioTracks,
+    contentTracks,
+    dragState,
+    getAudioTrackIndexFromClientY,
+    getContentTrackIndexFromClientY,
+    getTimeFromClientX,
+    mode,
+    moveAudioClip,
+    moveContentClip,
+    timelineDuration,
+    updateAudioClip,
+    updateContentClip,
+  ]);
 
-  return { dragState, setDragState, timelineContentRef };
+  React.useEffect(() => {
+    if (mode !== 'edit') {
+      setDragState(null);
+    }
+  }, [mode]);
+
+  return { dragState, setDragState, timelineContentRef, getTimeFromClientX };
 };
+
+const TimelineClip: React.FC<{
+  clip:
+    | (AudioClip & { kind: 'audio' })
+    | (ContentClip & { kind: 'content'; thumbnailUrl?: string });
+  timelineDuration: number;
+  isSelected: boolean;
+  isDragging: boolean;
+  isLocked: boolean;
+  mode: TimelineMode;
+  onBodyPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onResizeStart: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onResizeEnd: (event: React.PointerEvent<HTMLDivElement>) => void;
+}> = ({
+  clip,
+  timelineDuration,
+  isSelected,
+  isDragging,
+  isLocked,
+  mode,
+  onBodyPointerDown,
+  onResizeStart,
+  onResizeEnd,
+}) => {
+  const left = (clip.start / timelineDuration) * 100;
+  const width = (clip.duration / timelineDuration) * 100;
+  const canInteract = mode === 'edit' && !isLocked;
+
+  const baseClasses =
+    clip.kind === 'audio'
+      ? 'bg-green-600/80'
+      : 'bg-blue-500/80';
+
+  return (
+    <div
+      className={`absolute h-full flex items-center rounded-md overflow-hidden border border-black/40 transition-[box-shadow,transform] ${
+        isSelected ? 'ring-2 ring-blue-400' : ''
+      } ${isDragging ? 'shadow-xl scale-[1.01]' : ''}`}
+      style={{ left: `${left}%`, width: `${width}%`, height: '80%' }}
+    >
+      <div
+        role="presentation"
+        className={`w-1.5 h-full bg-white/30 cursor-ew-resize ${!canInteract ? 'cursor-default opacity-30' : ''}`}
+        onPointerDown={(event) => {
+          if (!canInteract) {
+            return;
+          }
+          onResizeStart(event);
+        }}
+      />
+      <div
+        role="button"
+        tabIndex={0}
+        onPointerDown={(event) => {
+          if (!canInteract) {
+            return;
+          }
+          onBodyPointerDown(event);
+        }}
+        className={`flex-1 h-full cursor-${canInteract ? 'grab' : 'default'} active:cursor-grabbing relative ${baseClasses}`}
+      >
+        {clip.kind === 'audio' ? (
+          <AudioWaveform seed={clip.id} />
+        ) : (
+          <div
+            className="absolute inset-0 bg-cover bg-center opacity-70"
+            style={{
+              backgroundImage: clip.thumbnailUrl ? `url(${clip.thumbnailUrl})` : undefined,
+            }}
+          />
+        )}
+        <div className="absolute inset-0 bg-black/30" />
+        <div className="absolute bottom-1 left-2 right-2 text-xs text-white font-semibold truncate pointer-events-none">
+          {clip.name}
+        </div>
+      </div>
+      <div
+        role="presentation"
+        className={`w-1.5 h-full bg-white/30 cursor-ew-resize ${!canInteract ? 'cursor-default opacity-30' : ''}`}
+        onPointerDown={(event) => {
+          if (!canInteract) {
+            return;
+          }
+          onResizeEnd(event);
+        }}
+      />
+    </div>
+  );
+};
+
+const ContentTrackHeader: React.FC<{
+  name: string;
+  locked?: boolean;
+  hidden?: boolean;
+  onToggleLock: () => void;
+  onToggleVisibility: () => void;
+  disableControls: boolean;
+}> = ({ name, locked, hidden, onToggleLock, onToggleVisibility, disableControls }) => (
+  <div className="h-20 flex items-center px-3 border-b border-zinc-800 space-x-2">
+    <div className="flex-1 flex flex-col justify-center">
+      <span className="font-bold text-sm">{name}</span>
+      <span className="text-xs text-gray-500">Video track</span>
+    </div>
+    <button
+      type="button"
+      className={`p-1 rounded ${hidden ? 'bg-zinc-600 text-yellow-300' : 'bg-zinc-700 text-gray-300'} ${
+        disableControls ? 'opacity-50 cursor-not-allowed' : 'hover:bg-zinc-600'
+      }`}
+      onClick={onToggleVisibility}
+      disabled={disableControls}
+    >
+      <EyeIcon className="w-4 h-4" />
+    </button>
+    <button
+      type="button"
+      className={`p-1 rounded ${locked ? 'bg-blue-500 text-white' : 'bg-zinc-700 text-gray-300'} ${
+        disableControls ? 'opacity-50 cursor-not-allowed' : 'hover:bg-zinc-600'
+      }`}
+      onClick={onToggleLock}
+      disabled={disableControls}
+    >
+      <LockIcon className="w-4 h-4" />
+    </button>
+  </div>
+);
+
+const AudioTrackHeader: React.FC<{
+  name: string;
+  muted?: boolean;
+  solo?: boolean;
+  locked?: boolean;
+  onToggleMute: () => void;
+  onToggleSolo: () => void;
+  onToggleLock: () => void;
+  disableControls: boolean;
+}> = ({ name, muted, solo, locked, onToggleMute, onToggleSolo, onToggleLock, disableControls }) => (
+  <div className="h-20 flex items-center px-3 border-b border-zinc-800 space-x-2">
+    <div className="flex-1 flex flex-col justify-center">
+      <span className="font-bold text-sm">{name}</span>
+      <span className="text-xs text-gray-500">Audio track</span>
+    </div>
+    <button
+      type="button"
+      className={`p-1 rounded w-7 h-7 text-xs font-bold ${muted ? 'bg-yellow-500 text-black' : 'bg-zinc-700 text-gray-300'} ${
+        disableControls ? 'opacity-50 cursor-not-allowed' : 'hover:bg-zinc-600'
+      }`}
+      onClick={onToggleMute}
+      disabled={disableControls}
+    >
+      M
+    </button>
+    <button
+      type="button"
+      className={`p-1 rounded w-7 h-7 text-xs font-bold ${solo ? 'bg-green-500 text-black' : 'bg-zinc-700 text-gray-300'} ${
+        disableControls ? 'opacity-50 cursor-not-allowed' : 'hover:bg-zinc-600'
+      }`}
+      onClick={onToggleSolo}
+      disabled={disableControls}
+    >
+      S
+    </button>
+    <button
+      type="button"
+      className={`p-1 rounded ${locked ? 'bg-blue-500 text-white' : 'bg-zinc-700 text-gray-300'} ${
+        disableControls ? 'opacity-50 cursor-not-allowed' : 'hover:bg-zinc-600'
+      }`}
+      onClick={onToggleLock}
+      disabled={disableControls}
+    >
+      <LockIcon className="w-4 h-4" />
+    </button>
+    <button className="p-1 text-gray-400 hover:text-red-500" type="button" disabled>
+      <MicIcon className="w-5 h-5" />
+    </button>
+  </div>
+);
 
 const Timeline: React.FC<{ height: number }> = ({ height }) => {
   const {
+    assets,
     audioTracks,
+    contentTracks,
+    addVisualClip,
     addMusicClip,
     updateAudioClip,
+    updateContentClip,
+    moveAudioClip,
+    moveContentClip,
+    toggleContentTrackLock,
+    toggleContentTrackVisibility,
+    toggleAudioTrackMute,
+    toggleAudioTrackSolo,
+    toggleAudioTrackLock,
     selectEntity,
     selected,
     timelineDuration,
+    currentTime,
+    setCurrentTime,
+    mode,
+    setMode,
+    isPlaying,
+    play,
+    pause,
   } = useCanvasState();
-  const { dragState, setDragState, timelineContentRef } = usePointerDrag(
-    timelineDuration,
-    audioTracks,
-    updateAudioClip
-  );
-  const selectedClipId = selected?.kind === 'audio' ? selected.id : null;
 
-  const getTimeFromClientX = React.useCallback(
-    (clientX: number) => {
-      const rect = timelineContentRef.current?.getBoundingClientRect();
-      if (!rect) {
-        return 0;
+  const contentTrackRefs = React.useRef<(HTMLDivElement | null)[]>([]);
+  const audioTrackRefs = React.useRef<(HTMLDivElement | null)[]>([]);
+
+  const getContentTrackIndexFromClientY = React.useCallback((clientY: number) => {
+    for (let index = 0; index < contentTrackRefs.current.length; index += 1) {
+      const element = contentTrackRefs.current[index];
+      if (!element) {
+        continue;
       }
-      const position = clamp(clientX - rect.left, 0, rect.width);
-      return rect.width === 0 ? 0 : (position / rect.width) * timelineDuration;
-    },
-    [timelineContentRef, timelineDuration]
+      const rect = element.getBoundingClientRect();
+      if (clientY >= rect.top && clientY <= rect.bottom) {
+        return index;
+      }
+    }
+    return null;
+  }, []);
+
+  const getAudioTrackIndexFromClientY = React.useCallback((clientY: number) => {
+    for (let index = 0; index < audioTrackRefs.current.length; index += 1) {
+      const element = audioTrackRefs.current[index];
+      if (!element) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      if (clientY >= rect.top && clientY <= rect.bottom) {
+        return index;
+      }
+    }
+    return null;
+  }, []);
+
+  const { dragState, setDragState, timelineContentRef, getTimeFromClientX } = useClipDrag(
+    timelineDuration,
+    contentTracks,
+    audioTracks,
+    updateContentClip,
+    updateAudioClip,
+    mode,
+    moveContentClip,
+    moveAudioClip,
+    getContentTrackIndexFromClientY,
+    getAudioTrackIndexFromClientY
   );
 
-  const handleClipPointerDown = React.useCallback(
-    (clip: AudioClip) => (event: React.PointerEvent<HTMLDivElement>) => {
+  const [scrubPointer, setScrubPointer] = React.useState<number | null>(null);
+
+  const selectedAudioClipId = selected?.kind === 'audio' ? selected.id : null;
+  const selectedContentClipId = React.useMemo(() => {
+    if (selected?.kind !== 'canvas') {
+      return null;
+    }
+    const asset = assets.find((item) => item.id === selected.id);
+    return asset?.timeline?.clipId ?? null;
+  }, [assets, selected]);
+
+  const handleTogglePlay = React.useCallback(() => {
+    if (isPlaying) {
+      pause();
+      return;
+    }
+    if (mode !== 'play') {
+      setMode('play');
+    }
+    play();
+  }, [isPlaying, mode, pause, play, setMode]);
+
+  const handleAudioClipPointerDown = React.useCallback(
+    (clip: AudioClip, trackLocked: boolean) => (event: React.PointerEvent<HTMLDivElement>) => {
+      if (mode !== 'edit' || trackLocked) {
+        return;
+      }
       event.preventDefault();
       const pointerTime = getTimeFromClientX(event.clientX);
-      const offset = pointerTime - clip.start;
-      setDragState({ mode: 'move', clipId: clip.id, pointerId: event.pointerId, offset });
+      setDragState({
+        mode: 'move',
+        clipId: clip.id,
+        pointerId: event.pointerId,
+        offset: pointerTime - clip.start,
+        kind: 'audio',
+      });
       selectEntity({ kind: 'audio', id: clip.id });
     },
-    [getTimeFromClientX, selectEntity, setDragState]
+    [getTimeFromClientX, mode, selectEntity, setDragState]
   );
 
-  const handleResize = React.useCallback(
-    (clip: AudioClip, mode: 'resize-start' | 'resize-end') =>
+  const handleContentClipPointerDown = React.useCallback(
+    (clip: ContentClip, trackLocked: boolean) => (event: React.PointerEvent<HTMLDivElement>) => {
+      if (mode !== 'edit' || trackLocked) {
+        return;
+      }
+      event.preventDefault();
+      const pointerTime = getTimeFromClientX(event.clientX);
+      setDragState({
+        mode: 'move',
+        clipId: clip.id,
+        pointerId: event.pointerId,
+        offset: pointerTime - clip.start,
+        kind: 'content',
+      });
+      selectEntity({ kind: 'canvas', id: clip.canvasAssetId });
+    },
+    [getTimeFromClientX, mode, selectEntity, setDragState]
+  );
+
+  const handleResizeStart = React.useCallback(
+    (clipId: string, kind: 'audio' | 'content', trackLocked: boolean) =>
       (event: React.PointerEvent<HTMLDivElement>) => {
+        if (mode !== 'edit' || trackLocked) {
+          return;
+        }
         event.preventDefault();
-        setDragState({ mode, clipId: clip.id, pointerId: event.pointerId, offset: 0 });
-        selectEntity({ kind: 'audio', id: clip.id });
+        setDragState({ mode: 'resize-start', clipId, pointerId: event.pointerId, offset: 0, kind });
       },
-    [selectEntity, setDragState]
+    [mode, setDragState]
   );
 
-  const handleTrackDrop = React.useCallback(
-    (trackIndex: number) => (event: React.DragEvent<HTMLDivElement>) => {
+  const handleResizeEnd = React.useCallback(
+    (clipId: string, kind: 'audio' | 'content', trackLocked: boolean) =>
+      (event: React.PointerEvent<HTMLDivElement>) => {
+        if (mode !== 'edit' || trackLocked) {
+          return;
+        }
+        event.preventDefault();
+        setDragState({ mode: 'resize-end', clipId, pointerId: event.pointerId, offset: 0, kind });
+      },
+    [mode, setDragState]
+  );
+
+  const handleContentTrackDrop = React.useCallback(
+    (trackIndex: number, locked: boolean) => (event: React.DragEvent<HTMLDivElement>) => {
+      if (mode !== 'edit' || locked) {
+        return;
+      }
+      if (!event.dataTransfer.types.includes(ASSET_DRAG_TYPE)) {
+        return;
+      }
+      event.preventDefault();
+      try {
+        const payload = JSON.parse(event.dataTransfer.getData(ASSET_DRAG_TYPE)) as {
+          assetId: string;
+          type: string;
+        };
+        if (payload.type === 'music') {
+          return;
+        }
+        const start = getTimeFromClientX(event.clientX);
+        addVisualClip(payload.assetId, { start, trackIndex });
+      } catch (error) {
+        // ignore invalid payloads
+      }
+    },
+    [addVisualClip, getTimeFromClientX, mode]
+  );
+
+  const handleAudioTrackDrop = React.useCallback(
+    (trackIndex: number, locked: boolean) => (event: React.DragEvent<HTMLDivElement>) => {
+      if (mode !== 'edit' || locked) {
+        return;
+      }
       if (!event.dataTransfer.types.includes(ASSET_DRAG_TYPE)) {
         return;
       }
@@ -308,7 +676,7 @@ const Timeline: React.FC<{ height: number }> = ({ height }) => {
         // ignore invalid payloads
       }
     },
-    [addMusicClip, getTimeFromClientX]
+    [addMusicClip, getTimeFromClientX, mode]
   );
 
   const handleDragOver = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -323,18 +691,60 @@ const Timeline: React.FC<{ height: number }> = ({ height }) => {
     [timelineDuration]
   );
 
+  const sliderPercentage = timelineDuration === 0 ? 0 : (currentTime / timelineDuration) * 100;
+
+  const startScrub = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const time = getTimeFromClientX(event.clientX);
+      setCurrentTime(time);
+      setScrubPointer(event.pointerId);
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    },
+    [getTimeFromClientX, setCurrentTime]
+  );
+
+  React.useEffect(() => {
+    if (scrubPointer === null) {
+      return undefined;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== scrubPointer) {
+        return;
+      }
+      setCurrentTime(getTimeFromClientX(event.clientX));
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId === scrubPointer) {
+        setScrubPointer(null);
+      }
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [getTimeFromClientX, scrubPointer, setCurrentTime]);
+
   return (
     <footer className="bg-[#252526] border-t border-zinc-700 flex flex-col flex-shrink-0" style={{ height }}>
-      <TimelineToolbar />
+      <TimelineToolbar isPlaying={isPlaying} onTogglePlay={handleTogglePlay} mode={mode} setMode={setMode} />
       <div className="flex flex-1 min-h-0">
         <TimelineTools />
         <div className="flex-1 overflow-auto relative" id="timeline-scroll-container">
           <div className="relative h-full" style={{ width: '200%' }} ref={timelineContentRef}>
-            <div className="h-8 flex sticky top-0 z-20 bg-[#252526]">
-              <div className="w-48 flex-shrink-0 sticky left-0 z-10 bg-[#252526] border-r border-b border-zinc-700 flex items-center justify-start p-2">
-                <span className="text-xs text-gray-400">00:00:00:00</span>
-              </div>
-              <div className="flex-1 border-b border-zinc-700 relative">
+            <div className="sticky top-0 z-20 bg-[#252526] border-b border-zinc-700">
+              <div className="relative h-14">
+                <div
+                  role="presentation"
+                  className="absolute inset-0 cursor-ew-resize"
+                  onPointerDown={startScrub}
+                />
+                <div className="absolute left-3 top-1 text-xs font-mono text-gray-300">{formatTime(currentTime)}</div>
                 {markers.map((time) => {
                   const percentage = (time / timelineDuration) * 100;
                   return (
@@ -343,45 +753,108 @@ const Timeline: React.FC<{ height: number }> = ({ height }) => {
                       className="absolute h-full flex flex-col items-start -translate-x-1/2"
                       style={{ left: `${percentage}%` }}
                     >
-                      <span className="text-xs text-gray-400">
-                        {new Date(time * 1000).toISOString().substr(14, 5)}
-                      </span>
-                      <div className="w-px h-2 bg-gray-500 mt-1" />
+                      <span className="text-xs text-gray-400">{new Date(time * 1000).toISOString().substr(14, 5)}</span>
+                      <div className="w-px h-3 bg-gray-500 mt-1" />
                     </div>
                   );
                 })}
+                <div
+                  className="absolute top-0 bottom-0 w-px bg-yellow-400"
+                  style={{ left: `${sliderPercentage}%` }}
+                />
+                <div
+                  className="absolute -bottom-1 w-2 h-2 rounded-full bg-yellow-400 translate-x-[-50%]"
+                  style={{ left: `${sliderPercentage}%` }}
+                />
               </div>
             </div>
 
             <div className="flex w-full">
               <div className="w-48 flex-shrink-0 sticky left-0 z-10 bg-[#252526] border-r border-zinc-700">
+                {contentTracks.map((track) => (
+                  <ContentTrackHeader
+                    key={track.id}
+                    name={track.name}
+                    locked={track.locked}
+                    hidden={track.hidden}
+                    onToggleLock={() => toggleContentTrackLock(track.id)}
+                    onToggleVisibility={() => toggleContentTrackVisibility(track.id)}
+                    disableControls={mode !== 'edit'}
+                  />
+                ))}
                 {audioTracks.map((track) => (
-                  <TrackHeader key={track.id} track={track} />
+                  <AudioTrackHeader
+                    key={track.id}
+                    name={track.name ?? track.id}
+                    muted={track.muted}
+                    solo={track.solo}
+                    locked={track.locked}
+                    onToggleMute={() => toggleAudioTrackMute(track.id)}
+                    onToggleSolo={() => toggleAudioTrackSolo(track.id)}
+                    onToggleLock={() => toggleAudioTrackLock(track.id)}
+                    disableControls={mode !== 'edit'}
+                  />
                 ))}
               </div>
               <div className="flex-1 relative">
-                {audioTracks.map((track, trackIndex) => (
+                {contentTracks.map((track, trackIndex) => (
                   <div
                     key={track.id}
-                    className="relative h-16 border-b border-zinc-800"
+                    className="relative h-20 border-b border-zinc-800"
                     onDragOver={handleDragOver}
-                    onDrop={handleTrackDrop(trackIndex)}
+                    onDrop={handleContentTrackDrop(trackIndex, Boolean(track.locked))}
+                    ref={(element) => {
+                      contentTrackRefs.current[trackIndex] = element;
+                    }}
                   >
                     {track.clips.map((clip) => (
                       <TimelineClip
                         key={clip.id}
-                        clip={clip}
+                        clip={{ ...clip, kind: 'content' }}
                         timelineDuration={timelineDuration}
-                        isSelected={selectedClipId === clip.id}
+                        isSelected={selectedContentClipId === clip.id}
                         isDragging={dragState?.clipId === clip.id}
-                        onBodyPointerDown={handleClipPointerDown(clip)}
-                        onResizeStart={handleResize(clip, 'resize-start')}
-                        onResizeEnd={handleResize(clip, 'resize-end')}
+                        isLocked={Boolean(track.locked)}
+                        mode={mode}
+                        onBodyPointerDown={handleContentClipPointerDown(clip, Boolean(track.locked))}
+                        onResizeStart={handleResizeStart(clip.id, 'content', Boolean(track.locked))}
+                        onResizeEnd={handleResizeEnd(clip.id, 'content', Boolean(track.locked))}
                       />
                     ))}
                     {track.clips.length === 0 && (
                       <div className="absolute inset-0 flex items-center justify-center text-xs text-gray-500 uppercase tracking-wide pointer-events-none">
-                        Drop music here
+                        Drop visuals here
+                      </div>
+                    )}
+                  </div>
+                ))}
+                {audioTracks.map((track, trackIndex) => (
+                  <div
+                    key={track.id}
+                    className="relative h-20 border-b border-zinc-800"
+                    onDragOver={handleDragOver}
+                    onDrop={handleAudioTrackDrop(trackIndex, Boolean(track.locked))}
+                    ref={(element) => {
+                      audioTrackRefs.current[trackIndex] = element;
+                    }}
+                  >
+                    {track.clips.map((clip) => (
+                      <TimelineClip
+                        key={clip.id}
+                        clip={{ ...clip, kind: 'audio' }}
+                        timelineDuration={timelineDuration}
+                        isSelected={selectedAudioClipId === clip.id}
+                        isDragging={dragState?.clipId === clip.id}
+                        isLocked={Boolean(track.locked)}
+                        mode={mode}
+                        onBodyPointerDown={handleAudioClipPointerDown(clip, Boolean(track.locked))}
+                        onResizeStart={handleResizeStart(clip.id, 'audio', Boolean(track.locked))}
+                        onResizeEnd={handleResizeEnd(clip.id, 'audio', Boolean(track.locked))}
+                      />
+                    ))}
+                    {track.clips.length === 0 && (
+                      <div className="absolute inset-0 flex items-center justify-center text-xs text-gray-500 uppercase tracking-wide pointer-events-none">
+                        Drop audio here
                       </div>
                     )}
                   </div>
@@ -392,9 +865,14 @@ const Timeline: React.FC<{ height: number }> = ({ height }) => {
         </div>
 
         <div className="w-16 border-l border-zinc-700 flex flex-col flex-shrink-0">
-          <div className="h-8 border-b border-zinc-700" />
+          <div className="h-14 border-b border-zinc-700" />
+          {contentTracks.map((track) => (
+            <div key={track.id} className="h-20 border-b border-zinc-800 flex items-center justify-center p-2">
+              <div className="text-xs text-gray-500">{track.clips.length} clips</div>
+            </div>
+          ))}
           {audioTracks.map((track) => (
-            <div key={track.id} className="h-16 border-b border-zinc-800 flex items-center justify-center p-2">
+            <div key={track.id} className="h-20 border-b border-zinc-800 flex items-center justify-center p-2">
               <div className="w-2 h-full bg-zinc-700 rounded-full overflow-hidden">
                 <div className="bg-green-500 w-full" style={{ height: `${track.clips.length > 0 ? 60 : 10}%` }} />
               </div>

--- a/constants.tsx
+++ b/constants.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { AssetCategory, LibraryAsset, AudioTrack } from './types';
+import type { AssetCategory, LibraryAsset, AudioTrack, ContentTrack } from './types';
 
 // Header Icons
 export const DeviceIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -155,9 +155,14 @@ export const LIBRARY_ASSETS: LibraryAsset[] = [
 
 export const ASSET_DRAG_TYPE = 'application/x-vid-asset';
 
+export const DEFAULT_CONTENT_TRACKS: ContentTrack[] = [
+  { id: 'V1', name: 'Video 1', clips: [], locked: false, hidden: false },
+  { id: 'V2', name: 'Video 2', clips: [], locked: false, hidden: false },
+];
+
 export const DEFAULT_AUDIO_TRACKS: AudioTrack[] = [
-  { id: 'A1', clips: [], muted: false, solo: false },
-  { id: 'A2', clips: [], muted: false, solo: false },
+  { id: 'A1', name: 'Audio 1', clips: [], muted: false, solo: false, locked: false },
+  { id: 'A2', name: 'Audio 2', clips: [], muted: false, solo: false, locked: false },
 ];
 
 // Timeline icons
@@ -189,6 +194,11 @@ export const StepBackwardIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props)
 export const PlayIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
   <svg {...props} viewBox="0 0 24 24" fill="currentColor">
     <path d="M8,5.14V19.14L19,12.14L8,5.14Z" />
+  </svg>
+);
+export const PauseIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M14,19H18V5H14M6,19H10V5H6V19Z" />
   </svg>
 );
 export const StepForwardIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (

--- a/context/CanvasStateContext.tsx
+++ b/context/CanvasStateContext.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
-import {
-  ASSET_DRAG_TYPE,
-  DEFAULT_AUDIO_TRACKS,
-  LIBRARY_ASSETS,
-  TIMELINE_DURATION,
-} from '../constants';
+import { DEFAULT_AUDIO_TRACKS, DEFAULT_CONTENT_TRACKS, LIBRARY_ASSETS, TIMELINE_DURATION } from '../constants';
 import type {
   AssetType,
   AudioClip,
   AudioTrack,
   CanvasAsset,
+  ContentClip,
+  ContentTrack,
   LibraryAsset,
   SelectedEntity,
+  TimelineMode,
   Transform,
 } from '../types';
 
@@ -22,27 +20,54 @@ const createId = () =>
     ? crypto.randomUUID()
     : `id-${Math.random().toString(36).slice(2, 9)}`;
 
-const cloneTracks = (tracks: AudioTrack[]): AudioTrack[] =>
+const cloneAudioTracks = (tracks: AudioTrack[]): AudioTrack[] =>
   tracks.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }));
+
+const cloneContentTracks = (tracks: ContentTrack[]): ContentTrack[] =>
+  tracks.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }));
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+const clampTimelineTime = (value: number) => clamp(value, 0, TIMELINE_DURATION);
 
 interface CanvasStateContextValue {
   assets: CanvasAsset[];
   audioTracks: AudioTrack[];
+  contentTracks: ContentTrack[];
   libraryAssets: LibraryAsset[];
   selected: SelectedEntity;
   selectEntity: (entity: SelectedEntity) => void;
   addAssetToCanvas: (
     assetId: string,
-    options?: { position?: { x: number; y: number }; size?: { width: number; height: number } }
-  ) => void;
+    options?: {
+      position?: { x: number; y: number };
+      size?: { width: number; height: number };
+      timeline?: CanvasAsset['timeline'];
+    }
+  ) => string | null;
   addMusicClip: (assetId: string, options?: { start?: number; trackIndex?: number }) => void;
+  addVisualClip: (assetId: string, options?: { start?: number; trackIndex?: number }) => void;
   updateAssetTransform: (assetId: string, updates: Partial<Transform>) => void;
   toggleAssetVisibility: (assetId: string) => void;
   toggleAssetLock: (assetId: string) => void;
   removeEntity: (entity: SelectedEntity) => void;
   reorderAssetZIndex: (assetId: string, direction: 1 | -1) => void;
   updateAudioClip: (clipId: string, updates: Partial<AudioClip>) => void;
+  updateContentClip: (clipId: string, updates: Partial<ContentClip>) => void;
+  moveAudioClip: (clipId: string, trackIndex: number) => void;
+  moveContentClip: (clipId: string, trackIndex: number) => void;
+  toggleContentTrackLock: (trackId: string) => void;
+  toggleContentTrackVisibility: (trackId: string) => void;
+  toggleAudioTrackMute: (trackId: string) => void;
+  toggleAudioTrackSolo: (trackId: string) => void;
+  toggleAudioTrackLock: (trackId: string) => void;
   timelineDuration: number;
+  currentTime: number;
+  setCurrentTime: (time: number) => void;
+  mode: TimelineMode;
+  setMode: (mode: TimelineMode) => void;
+  isPlaying: boolean;
+  play: () => void;
+  pause: () => void;
 }
 
 const CanvasStateContext = React.createContext<CanvasStateContextValue | undefined>(undefined);
@@ -52,7 +77,13 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const [audioTracks, setAudioTracks] = React.useState<AudioTrack[]>(() =>
     DEFAULT_AUDIO_TRACKS.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }))
   );
+  const [contentTracks, setContentTracks] = React.useState<ContentTrack[]>(() =>
+    DEFAULT_CONTENT_TRACKS.map((track) => ({ ...track, clips: track.clips.map((clip) => ({ ...clip })) }))
+  );
   const [selected, setSelected] = React.useState<SelectedEntity>(null);
+  const [mode, setMode] = React.useState<TimelineMode>('edit');
+  const [currentTime, setCurrentTimeState] = React.useState(0);
+  const [isPlaying, setIsPlaying] = React.useState(false);
 
   const libraryLookup = React.useMemo(() => {
     const map = new Map<string, LibraryAsset>();
@@ -66,11 +97,25 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
     setSelected(entity);
   }, []);
 
+  const setCurrentTime = React.useCallback((time: number) => {
+    setCurrentTimeState((prev) => {
+      const next = clampTimelineTime(time);
+      if (next === prev) {
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
   const addAssetToCanvas = React.useCallback<CanvasStateContextValue['addAssetToCanvas']>(
     (assetId, options = {}) => {
+      if (mode !== 'edit') {
+        return null;
+      }
+
       const libraryAsset = libraryLookup.get(assetId);
       if (!libraryAsset || libraryAsset.type === 'music') {
-        return;
+        return null;
       }
 
       const baseTransform: Transform = {
@@ -103,29 +148,34 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
       const createdId = createId();
 
-      setAssets((prev) => [
-        ...prev,
-        {
-          id: createdId,
-          assetId: libraryAsset.id,
-          name: libraryAsset.name,
-          type: libraryAsset.type as Exclude<AssetType, 'music'>,
-          mediaUrl: libraryAsset.mediaUrl,
-          thumbnailUrl: libraryAsset.thumbnailUrl,
-          transform: baseTransform,
-          zIndex: prev.length + 1,
-          isLocked: false,
-          isVisible: true,
-        },
-      ]);
+      const newAsset: CanvasAsset = {
+        id: createdId,
+        assetId: libraryAsset.id,
+        name: libraryAsset.name,
+        type: libraryAsset.type as Exclude<AssetType, 'music'>,
+        mediaUrl: libraryAsset.mediaUrl,
+        thumbnailUrl: libraryAsset.thumbnailUrl,
+        transform: baseTransform,
+        zIndex: assets.length + 1,
+        isLocked: false,
+        isVisible: true,
+        timeline: options.timeline ? { ...options.timeline, clipId: options.timeline.clipId } : undefined,
+      };
 
+      setAssets((prev) => [...prev, newAsset]);
       setSelected({ kind: 'canvas', id: createdId });
+
+      return createdId;
     },
-    [libraryLookup]
+    [assets.length, libraryLookup, mode]
   );
 
   const addMusicClip = React.useCallback<CanvasStateContextValue['addMusicClip']>(
     (assetId, options = {}) => {
+      if (mode !== 'edit') {
+        return;
+      }
+
       const libraryAsset = libraryLookup.get(assetId);
       if (!libraryAsset || libraryAsset.type !== 'music') {
         return;
@@ -134,55 +184,115 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
       const clipId = createId();
 
       setAudioTracks((prev) => {
-        const tracks = cloneTracks(prev);
+        const tracks = cloneAudioTracks(prev);
         const duration = libraryAsset.duration ?? 120;
         const desiredTrack =
-          typeof options.trackIndex === 'number' ? options.trackIndex : tracks.findIndex(() => true);
-        const trackIndex = desiredTrack >= 0 ? desiredTrack : 0;
-        const track = tracks[trackIndex] ?? tracks[0];
+          typeof options.trackIndex === 'number' ? clamp(options.trackIndex, 0, tracks.length - 1) : 0;
+        const track = tracks[desiredTrack];
 
-        if (!track) {
+        if (!track || track.locked) {
           return prev;
         }
 
-        const start = Math.max(0, Math.min(options.start ?? 0, TIMELINE_DURATION - 1));
+        const start = clampTimelineTime(options.start ?? currentTime);
         const clip: AudioClip = {
           id: clipId,
           assetId: libraryAsset.id,
           name: libraryAsset.name,
           start,
-          duration: Math.min(duration, TIMELINE_DURATION - start),
+          duration: Math.max(1, Math.min(duration, TIMELINE_DURATION - start)),
           source: libraryAsset.mediaUrl,
           volume: 0.8,
           fadeIn: 0,
           fadeOut: 0,
         };
 
-        track.clips.push(clip);
-        tracks[trackIndex] = { ...track, clips: [...track.clips] };
+        track.clips = [...track.clips, clip];
+        tracks[desiredTrack] = { ...track };
         return tracks;
       });
 
       setSelected({ kind: 'audio', id: clipId });
     },
-    [libraryLookup]
+    [currentTime, libraryLookup, mode]
   );
 
-  const updateAssetTransform = React.useCallback<CanvasStateContextValue['updateAssetTransform']>((assetId, updates) => {
-    setAssets((prev) =>
-      prev.map((asset) =>
-        asset.id === assetId
-          ? {
-              ...asset,
-              transform: {
-                ...asset.transform,
-                ...updates,
-              },
-            }
-          : asset
-      )
-    );
-  }, []);
+  const addVisualClip = React.useCallback<CanvasStateContextValue['addVisualClip']>(
+    (assetId, options = {}) => {
+      if (mode !== 'edit') {
+        return;
+      }
+
+      const libraryAsset = libraryLookup.get(assetId);
+      if (!libraryAsset || libraryAsset.type === 'music') {
+        return;
+      }
+
+      setContentTracks((prev) => {
+        const tracks = cloneContentTracks(prev);
+        const desiredTrack =
+          typeof options.trackIndex === 'number' ? clamp(options.trackIndex, 0, tracks.length - 1) : 0;
+        const track = tracks[desiredTrack];
+
+        if (!track || track.locked) {
+          return prev;
+        }
+
+        const clipId = createId();
+        const start = clampTimelineTime(options.start ?? currentTime);
+        const estimatedDuration = libraryAsset.duration ?? 45;
+        const duration = Math.max(1, Math.min(estimatedDuration, TIMELINE_DURATION - start));
+        const timelineMeta = { start, duration, trackId: track.id, clipId };
+        const createdAssetId =
+          addAssetToCanvas(assetId, {
+            timeline: timelineMeta,
+          }) ?? null;
+
+        if (!createdAssetId) {
+          return prev;
+        }
+
+        const clip: ContentClip = {
+          id: clipId,
+          assetId: libraryAsset.id,
+          canvasAssetId: createdAssetId,
+          name: libraryAsset.name,
+          start,
+          duration,
+          type: 'image',
+          thumbnailUrl: libraryAsset.thumbnailUrl,
+        };
+
+        track.clips = [...track.clips, clip];
+        tracks[desiredTrack] = { ...track };
+        return tracks;
+      });
+    },
+    [addAssetToCanvas, currentTime, libraryLookup, mode]
+  );
+
+  const updateAssetTransform = React.useCallback<CanvasStateContextValue['updateAssetTransform']>(
+    (assetId, updates) => {
+      if (mode !== 'edit') {
+        return;
+      }
+
+      setAssets((prev) =>
+        prev.map((asset) =>
+          asset.id === assetId
+            ? {
+                ...asset,
+                transform: {
+                  ...asset.transform,
+                  ...updates,
+                },
+              }
+            : asset
+        )
+      );
+    },
+    [mode]
+  );
 
   const toggleAssetVisibility = React.useCallback<CanvasStateContextValue['toggleAssetVisibility']>((assetId) => {
     setAssets((prev) =>
@@ -211,6 +321,10 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
   }, []);
 
   const reorderAssetZIndex = React.useCallback<CanvasStateContextValue['reorderAssetZIndex']>((assetId, direction) => {
+    if (mode !== 'edit') {
+      return;
+    }
+
     setAssets((prev) => {
       const next = [...prev];
       const index = next.findIndex((asset) => asset.id === assetId);
@@ -229,14 +343,21 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
       return next.map((asset, idx) => ({ ...asset, zIndex: idx + 1 }));
     });
-  }, []);
+  }, [mode]);
 
   const updateAudioClip = React.useCallback<CanvasStateContextValue['updateAudioClip']>((clipId, updates) => {
+    if (mode !== 'edit') {
+      return;
+    }
+
     setAudioTracks((prev) => {
-      const tracks = cloneTracks(prev);
+      const tracks = cloneAudioTracks(prev);
 
       for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
         const track = tracks[trackIndex];
+        if (track.locked) {
+          continue;
+        }
         const clipIndex = track.clips.findIndex((clip) => clip.id === clipId);
         if (clipIndex !== -1) {
           const clip = track.clips[clipIndex];
@@ -245,44 +366,318 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
             ...updates,
           };
 
-          nextClip.start = Math.max(0, Math.min(nextClip.start, TIMELINE_DURATION - 1));
+          nextClip.start = clampTimelineTime(nextClip.start);
+          nextClip.duration = clampTimelineTime(nextClip.duration);
           nextClip.duration = Math.max(1, Math.min(nextClip.duration, TIMELINE_DURATION - nextClip.start));
 
-          track.clips[clipIndex] = nextClip;
-          tracks[trackIndex] = { ...track, clips: [...track.clips] };
+          track.clips = track.clips.map((item, index) => (index === clipIndex ? nextClip : item));
+          tracks[trackIndex] = { ...track };
           return tracks;
         }
       }
 
       return prev;
     });
+  }, [mode]);
+
+  const moveAudioClip = React.useCallback<CanvasStateContextValue['moveAudioClip']>((clipId, targetTrackIndex) => {
+    if (mode !== 'edit') {
+      return;
+    }
+
+    setAudioTracks((prev) => {
+      if (targetTrackIndex < 0 || targetTrackIndex >= prev.length) {
+        return prev;
+      }
+
+      const tracks = cloneAudioTracks(prev);
+      let sourceTrackIndex = -1;
+      let clip: AudioClip | null = null;
+
+      for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
+        const track = tracks[trackIndex];
+        const foundIndex = track.clips.findIndex((item) => item.id === clipId);
+        if (foundIndex !== -1) {
+          if (track.locked) {
+            return prev;
+          }
+          sourceTrackIndex = trackIndex;
+          clip = track.clips[foundIndex];
+          break;
+        }
+      }
+
+      if (!clip || sourceTrackIndex === targetTrackIndex) {
+        return prev;
+      }
+
+      const destinationTrack = tracks[targetTrackIndex];
+      if (!destinationTrack || destinationTrack.locked) {
+        return prev;
+      }
+
+      const sourceTrack = tracks[sourceTrackIndex];
+      sourceTrack.clips = sourceTrack.clips.filter((item) => item.id !== clipId);
+      tracks[sourceTrackIndex] = { ...sourceTrack };
+
+      destinationTrack.clips = [...destinationTrack.clips, clip].sort((a, b) => a.start - b.start);
+      tracks[targetTrackIndex] = { ...destinationTrack };
+
+      return tracks;
+    });
+  }, [mode]);
+
+  const updateContentClip = React.useCallback<CanvasStateContextValue['updateContentClip']>((clipId, updates) => {
+    if (mode !== 'edit') {
+      return;
+    }
+
+    let assetUpdate: { assetId: string; start: number; duration: number; trackId: string } | null = null;
+
+    setContentTracks((prev) => {
+      const tracks = cloneContentTracks(prev);
+
+      for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
+        const track = tracks[trackIndex];
+        if (track.locked) {
+          continue;
+        }
+        const clipIndex = track.clips.findIndex((clip) => clip.id === clipId);
+        if (clipIndex !== -1) {
+          const clip = track.clips[clipIndex];
+          const nextClip: ContentClip = {
+            ...clip,
+            ...updates,
+          };
+
+          nextClip.start = clampTimelineTime(nextClip.start);
+          nextClip.duration = Math.max(1, Math.min(nextClip.duration, TIMELINE_DURATION - nextClip.start));
+
+          track.clips = track.clips.map((item, index) => (index === clipIndex ? nextClip : item));
+          tracks[trackIndex] = { ...track };
+
+          assetUpdate = {
+            assetId: nextClip.canvasAssetId,
+            start: nextClip.start,
+            duration: nextClip.duration,
+            trackId: track.id,
+          };
+          return tracks;
+        }
+      }
+
+      return prev;
+    });
+
+    if (assetUpdate) {
+      setAssets((prev) =>
+        prev.map((asset) =>
+          asset.id === assetUpdate?.assetId
+            ? {
+                ...asset,
+                timeline: asset.timeline
+                  ? {
+                      ...asset.timeline,
+                      start: assetUpdate.start,
+                      duration: assetUpdate.duration,
+                      trackId: assetUpdate.trackId,
+                    }
+                  : {
+                      start: assetUpdate.start,
+                      duration: assetUpdate.duration,
+                      trackId: assetUpdate.trackId,
+                      clipId: clipId,
+                    },
+              }
+            : asset
+        )
+      );
+    }
+  }, [mode]);
+
+  const moveContentClip = React.useCallback<CanvasStateContextValue['moveContentClip']>((clipId, targetTrackIndex) => {
+    if (mode !== 'edit') {
+      return;
+    }
+
+    let assetUpdate: { assetId: string; trackId: string; start: number; duration: number } | null = null;
+
+    setContentTracks((prev) => {
+      if (targetTrackIndex < 0 || targetTrackIndex >= prev.length) {
+        return prev;
+      }
+
+      const tracks = cloneContentTracks(prev);
+      let sourceTrackIndex = -1;
+      let clip: ContentClip | null = null;
+
+      for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
+        const track = tracks[trackIndex];
+        const foundIndex = track.clips.findIndex((item) => item.id === clipId);
+        if (foundIndex !== -1) {
+          if (track.locked) {
+            return prev;
+          }
+          sourceTrackIndex = trackIndex;
+          clip = track.clips[foundIndex];
+          break;
+        }
+      }
+
+      if (!clip || sourceTrackIndex === targetTrackIndex) {
+        return prev;
+      }
+
+      const destinationTrack = tracks[targetTrackIndex];
+      if (!destinationTrack || destinationTrack.locked) {
+        return prev;
+      }
+
+      const sourceTrack = tracks[sourceTrackIndex];
+      sourceTrack.clips = sourceTrack.clips.filter((item) => item.id !== clipId);
+      tracks[sourceTrackIndex] = { ...sourceTrack };
+
+      destinationTrack.clips = [...destinationTrack.clips, clip].sort((a, b) => a.start - b.start);
+      tracks[targetTrackIndex] = { ...destinationTrack };
+
+      assetUpdate = {
+        assetId: clip.canvasAssetId,
+        trackId: destinationTrack.id,
+        start: clip.start,
+        duration: clip.duration,
+      };
+
+      return tracks;
+    });
+
+    if (assetUpdate) {
+      setAssets((prev) =>
+        prev.map((asset) =>
+          asset.id === assetUpdate?.assetId
+            ? {
+                ...asset,
+                timeline: asset.timeline
+                  ? {
+                      ...asset.timeline,
+                      trackId: assetUpdate.trackId,
+                      start: assetUpdate.start,
+                      duration: assetUpdate.duration,
+                    }
+                  : {
+                      start: assetUpdate.start,
+                      duration: assetUpdate.duration,
+                      trackId: assetUpdate.trackId,
+                      clipId,
+                    },
+              }
+            : asset
+        )
+      );
+    }
+  }, [mode]);
+
+  const toggleContentTrackLock = React.useCallback<CanvasStateContextValue['toggleContentTrackLock']>((trackId) => {
+    setContentTracks((prev) =>
+      prev.map((track) =>
+        track.id === trackId
+          ? {
+              ...track,
+              locked: !track.locked,
+            }
+          : track
+      )
+    );
+  }, []);
+
+  const toggleContentTrackVisibility = React.useCallback<CanvasStateContextValue['toggleContentTrackVisibility']>((trackId) => {
+    setContentTracks((prev) =>
+      prev.map((track) =>
+        track.id === trackId
+          ? {
+              ...track,
+              hidden: !track.hidden,
+            }
+          : track
+      )
+    );
+  }, []);
+
+  const toggleAudioTrackMute = React.useCallback<CanvasStateContextValue['toggleAudioTrackMute']>((trackId) => {
+    setAudioTracks((prev) =>
+      prev.map((track) =>
+        track.id === trackId
+          ? {
+              ...track,
+              muted: !track.muted,
+            }
+          : track
+      )
+    );
+  }, []);
+
+  const toggleAudioTrackSolo = React.useCallback<CanvasStateContextValue['toggleAudioTrackSolo']>((trackId) => {
+    setAudioTracks((prev) =>
+      prev.map((track) =>
+        track.id === trackId
+          ? {
+              ...track,
+              solo: !track.solo,
+            }
+          : track
+      )
+    );
+  }, []);
+
+  const toggleAudioTrackLock = React.useCallback<CanvasStateContextValue['toggleAudioTrackLock']>((trackId) => {
+    setAudioTracks((prev) =>
+      prev.map((track) =>
+        track.id === trackId
+          ? {
+              ...track,
+              locked: !track.locked,
+            }
+          : track
+      )
+    );
   }, []);
 
   const removeEntity = React.useCallback<CanvasStateContextValue['removeEntity']>((entity) => {
-    if (!entity) {
+    if (!entity || mode !== 'edit') {
       return;
     }
 
     if (entity.kind === 'canvas') {
-      setAssets((prev) => prev.filter((asset) => asset.id !== entity.id));
-    } else if (entity.kind === 'audio') {
-      setAudioTracks((prev) => {
-        const tracks = cloneTracks(prev);
-        for (let trackIndex = 0; trackIndex < tracks.length; trackIndex += 1) {
-          const track = tracks[trackIndex];
-          const nextClips = track.clips.filter((clip) => clip.id !== entity.id);
-          tracks[trackIndex] = { ...track, clips: nextClips };
-        }
-        return tracks;
+      let clipIdToRemove: string | null = null;
+      setAssets((prev) => {
+        const target = prev.find((asset) => asset.id === entity.id);
+        clipIdToRemove = target?.timeline?.clipId ?? null;
+        return prev.filter((asset) => asset.id !== entity.id);
       });
+
+      if (clipIdToRemove) {
+        const removeId = clipIdToRemove;
+        setContentTracks((prev) =>
+          prev.map((track) => ({
+            ...track,
+            clips: track.clips.filter((clip) => clip.id !== removeId),
+          }))
+        );
+      }
+    } else if (entity.kind === 'audio') {
+      setAudioTracks((prev) =>
+        prev.map((track) => ({
+          ...track,
+          clips: track.clips.filter((clip) => clip.id !== entity.id),
+        }))
+      );
     }
 
     setSelected(null);
-  }, []);
+  }, [mode]);
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.key === 'Delete' || event.key === 'Backspace') && selected) {
+      if ((event.key === 'Delete' || event.key === 'Backspace') && selected && mode === 'edit') {
         event.preventDefault();
         removeEntity(selected);
       }
@@ -290,38 +685,116 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [removeEntity, selected]);
+  }, [removeEntity, selected, mode]);
+
+  React.useEffect(() => {
+    if (!isPlaying) {
+      return undefined;
+    }
+
+    let frameId: number;
+    let last = performance.now();
+
+    const step = (now: number) => {
+      const delta = (now - last) / 1000;
+      last = now;
+      setCurrentTimeState((prev) => {
+        const next = clampTimelineTime(prev + delta);
+        if (next >= TIMELINE_DURATION) {
+          setIsPlaying(false);
+          return TIMELINE_DURATION;
+        }
+        return next;
+      });
+      frameId = requestAnimationFrame(step);
+    };
+
+    frameId = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frameId);
+  }, [isPlaying]);
+
+  React.useEffect(() => {
+    if (mode === 'edit' && isPlaying) {
+      setIsPlaying(false);
+    }
+  }, [mode, isPlaying]);
+
+  const play = React.useCallback(() => {
+    if (currentTime >= TIMELINE_DURATION) {
+      setCurrentTimeState(0);
+    }
+    setMode('play');
+    setIsPlaying(true);
+  }, [currentTime]);
+
+  const pause = React.useCallback(() => {
+    setIsPlaying(false);
+  }, []);
 
   const value = React.useMemo<CanvasStateContextValue>(
     () => ({
       assets,
       audioTracks,
+      contentTracks,
       libraryAssets: LIBRARY_ASSETS,
       selected,
       selectEntity,
       addAssetToCanvas,
       addMusicClip,
+      addVisualClip,
       updateAssetTransform,
       toggleAssetVisibility,
       toggleAssetLock,
       removeEntity,
       reorderAssetZIndex,
       updateAudioClip,
+      updateContentClip,
+      moveAudioClip,
+      moveContentClip,
+      toggleContentTrackLock,
+      toggleContentTrackVisibility,
+      toggleAudioTrackMute,
+      toggleAudioTrackSolo,
+      toggleAudioTrackLock,
       timelineDuration: TIMELINE_DURATION,
+      currentTime,
+      setCurrentTime,
+      mode,
+      setMode,
+      isPlaying,
+      play,
+      pause,
     }),
     [
       assets,
       audioTracks,
+      contentTracks,
       selected,
       selectEntity,
       addAssetToCanvas,
       addMusicClip,
+      addVisualClip,
       updateAssetTransform,
       toggleAssetVisibility,
       toggleAssetLock,
       removeEntity,
       reorderAssetZIndex,
       updateAudioClip,
+      updateContentClip,
+      moveAudioClip,
+      moveContentClip,
+      toggleContentTrackLock,
+      toggleContentTrackVisibility,
+      toggleAudioTrackMute,
+      toggleAudioTrackSolo,
+      toggleAudioTrackLock,
+      currentTime,
+      setCurrentTime,
+      mode,
+      setMode,
+      isPlaying,
+      play,
+      pause,
     ]
   );
 
@@ -335,10 +808,3 @@ export const useCanvasState = (): CanvasStateContextValue => {
   }
   return context;
 };
-
-export const useLibraryAsset = (assetId: string): LibraryAsset | undefined => {
-  const { libraryAssets } = useCanvasState();
-  return React.useMemo(() => libraryAssets.find((asset) => asset.id === assetId), [libraryAssets, assetId]);
-};
-
-export { ASSET_DRAG_TYPE };

--- a/context/CanvasStateContext.tsx
+++ b/context/CanvasStateContext.tsx
@@ -719,6 +719,15 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
     }
   }, [mode, isPlaying]);
 
+  const wasPlayingRef = React.useRef(isPlaying);
+
+  React.useEffect(() => {
+    if (wasPlayingRef.current && !isPlaying && mode === 'play') {
+      setMode('edit');
+    }
+    wasPlayingRef.current = isPlaying;
+  }, [isPlaying, mode]);
+
   const play = React.useCallback(() => {
     if (currentTime >= TIMELINE_DURATION) {
       setCurrentTimeState(0);

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@
 import type React from 'react';
 
 export type AssetType = 'character' | 'background' | 'music' | 'graphic';
+export type TimelineMode = 'edit' | 'play';
 
 export interface AssetCategory {
   name: string;
@@ -44,6 +45,7 @@ export interface CanvasAsset {
   zIndex: number;
   isLocked: boolean;
   isVisible: boolean;
+  timeline?: CanvasAssetTimeline;
 }
 
 export interface AudioClip {
@@ -63,9 +65,37 @@ export interface AudioTrack {
   clips: AudioClip[];
   muted?: boolean;
   solo?: boolean;
+  locked?: boolean;
+  name?: string;
 }
 
 export type SelectedEntity =
   | { kind: 'canvas'; id: string }
   | { kind: 'audio'; id: string }
   | null;
+
+export interface CanvasAssetTimeline {
+  start: number;
+  duration: number;
+  trackId: string;
+  clipId: string;
+}
+
+export interface ContentClip {
+  id: string;
+  assetId: string;
+  canvasAssetId: string;
+  name: string;
+  start: number;
+  duration: number;
+  type: 'image' | 'video';
+  thumbnailUrl?: string;
+}
+
+export interface ContentTrack {
+  id: string;
+  name: string;
+  clips: ContentClip[];
+  locked?: boolean;
+  hidden?: boolean;
+}


### PR DESCRIPTION
## Summary
- derive timeline-aware z-index values so content clips hide when their playhead is outside the clip range and the stage reflects track visibility
- render canvas assets with the computed z-order so clips from higher tracks appear above lower tracks when moved between rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e05183dd548325b8f5577de5cfa0a2