### PR TITLE
Allow moving canvas clips between timeline tracks

### DIFF
--- a/context/CanvasStateContext.tsx
+++ b/context/CanvasStateContext.tsx
@@ -52,7 +52,10 @@ interface CanvasStateContextValue {
   removeEntity: (entity: SelectedEntity) => void;
   reorderAssetZIndex: (assetId: string, direction: 1 | -1) => void;
   updateAudioClip: (clipId: string, updates: Partial<AudioClip>) => void;
-  updateContentClip: (clipId: string, updates: Partial<ContentClip>) => void;
+  updateContentClip: (
+    clipId: string,
+    updates: (Partial<ContentClip> & { trackId?: string })
+  ) => void;
   toggleContentTrackLock: (trackId: string) => void;
   toggleContentTrackVisibility: (trackId: string) => void;
   toggleAudioTrackMute: (trackId: string) => void;
@@ -146,6 +149,24 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
       const createdId = createId();
 
+      let timelineMeta = options.timeline ? { ...options.timeline } : undefined;
+      let shouldCreateTimelineClip = false;
+
+      if (!timelineMeta) {
+        const availableTrack = contentTracks.find((track) => !track.locked) ?? contentTracks[0];
+        if (!availableTrack) {
+          return null;
+        }
+
+        const start = clampTimelineTime(currentTime);
+        const estimatedDuration = libraryAsset.duration ?? 45;
+        const duration = Math.max(1, Math.min(estimatedDuration, TIMELINE_DURATION - start));
+        timelineMeta = { start, duration, trackId: availableTrack.id, clipId: createId() };
+        shouldCreateTimelineClip = true;
+      } else if (!timelineMeta.clipId) {
+        timelineMeta.clipId = createId();
+      }
+
       const newAsset: CanvasAsset = {
         id: createdId,
         assetId: libraryAsset.id,
@@ -157,15 +178,44 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
         zIndex: assets.length + 1,
         isLocked: false,
         isVisible: true,
-        timeline: options.timeline ? { ...options.timeline, clipId: options.timeline.clipId } : undefined,
+        timeline: timelineMeta,
       };
 
       setAssets((prev) => [...prev, newAsset]);
       setSelected({ kind: 'canvas', id: createdId });
 
+      if (shouldCreateTimelineClip && timelineMeta) {
+        const clipType: ContentClip['type'] =
+          libraryAsset.type === 'character' || libraryAsset.type === 'graphic' || libraryAsset.type === 'background'
+            ? 'image'
+            : 'video';
+
+        const clip: ContentClip = {
+          id: timelineMeta.clipId,
+          assetId: libraryAsset.id,
+          canvasAssetId: createdId,
+          name: libraryAsset.name,
+          start: timelineMeta.start,
+          duration: timelineMeta.duration,
+          type: clipType,
+          thumbnailUrl: libraryAsset.thumbnailUrl,
+        };
+
+        setContentTracks((prev) =>
+          prev.map((track) =>
+            track.id === timelineMeta.trackId
+              ? {
+                  ...track,
+                  clips: [...track.clips, clip],
+                }
+              : track
+          )
+        );
+      }
+
       return createdId;
     },
-    [assets.length, libraryLookup, mode]
+    [assets.length, contentTracks, currentTime, libraryLookup, mode]
   );
 
   const addMusicClip = React.useCallback<CanvasStateContextValue['addMusicClip']>(
@@ -396,22 +446,45 @@ export const CanvasStateProvider: React.FC<{ children: React.ReactNode }> = ({ c
         const clipIndex = track.clips.findIndex((clip) => clip.id === clipId);
         if (clipIndex !== -1) {
           const clip = track.clips[clipIndex];
+          const { trackId: targetTrackId, ...clipUpdates } = updates;
           const nextClip: ContentClip = {
             ...clip,
-            ...updates,
+            ...clipUpdates,
           };
 
           nextClip.start = clampTimelineTime(nextClip.start);
           nextClip.duration = Math.max(1, Math.min(nextClip.duration, TIMELINE_DURATION - nextClip.start));
 
-          track.clips = track.clips.map((item, index) => (index === clipIndex ? nextClip : item));
-          tracks[trackIndex] = { ...track };
+          const destinationTrackId = targetTrackId ?? track.id;
+
+          if (targetTrackId && targetTrackId !== track.id) {
+            const destinationIndex = tracks.findIndex((item) => item.id === targetTrackId);
+            if (destinationIndex === -1) {
+              return prev;
+            }
+
+            const destinationTrack = tracks[destinationIndex];
+            if (destinationTrack.locked) {
+              return prev;
+            }
+
+            track.clips = track.clips.filter((item) => item.id !== clipId);
+            tracks[trackIndex] = { ...track, clips: [...track.clips].sort((a, b) => a.start - b.start) };
+
+            destinationTrack.clips = [...destinationTrack.clips, nextClip].sort((a, b) => a.start - b.start);
+            tracks[destinationIndex] = { ...destinationTrack };
+          } else {
+            track.clips = track.clips
+              .map((item, index) => (index === clipIndex ? nextClip : item))
+              .sort((a, b) => a.start - b.start);
+            tracks[trackIndex] = { ...track };
+          }
 
           assetUpdate = {
             assetId: nextClip.canvasAssetId,
             start: nextClip.start,
             duration: nextClip.duration,
-            trackId: track.id,
+            trackId: destinationTrackId,
           };
           return tracks;
         }


### PR DESCRIPTION
## Summary
- allow visual clips to be reassigned between timeline tracks while keeping canvas metadata in sync
- capture track context during drags so releasing a clip over another video lane updates its track
- move the playhead to the drop position when adding assets directly to the timeline so the canvas reveals the new clip immediately

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e064070e9483258bbba7c6e91a0d08